### PR TITLE
feat: display GUI windows at monitor center

### DIFF
--- a/ui/HotstringManager.ahk
+++ b/ui/HotstringManager.ahk
@@ -22,6 +22,7 @@ class HotstringManager {
     ; --- クラス定数（可読性と保守性のための定数値） ---
     static GUI_WIDTH := 420
     static GUI_HEIGHT_EST := 350
+    static WINDOW_FRAME_WIDTH := 14  ; ウィンドウフレーム補正値（Win10/11標準テーマ）
     static LV_ROWS := 10
     static COL_WIDTH_TRIG := 100
     static COL_WIDTH_REPL := 280
@@ -116,31 +117,18 @@ class HotstringManager {
             this._BuildGui()
         }
 
-        CoordMode "Caret", "Screen"
+        ; マウスカーソルがあるモニタの作業領域中央に配置
         CoordMode "Mouse", "Screen"
+        MouseGetPos(&mX, &mY)
+        monitorNum := this._GetMonitorFromPos(mX, mY)
+        MonitorGetWorkArea(monitorNum, &waL, &waT, &waR, &waB)
 
-        targetX := 0
-        targetY := 0
+        winW := this.GUI_WIDTH + this.WINDOW_FRAME_WIDTH
+        winH := this.GUI_HEIGHT_EST
+        centerX := waL + (waR - waL - winW) // 2
+        centerY := waT + (waB - waT - winH) // 2
 
-        ; キャレット位置を優先的に取得
-        if CaretGetPos(&cX, &cY) {
-            targetX := cX + this.OFFSET_CARET
-            monitorNum := this._GetMonitorFromPos(cX, cY)
-            MonitorGetWorkArea(monitorNum, &L, &T, &R, &B)
-
-            if (cY + this.OFFSET_LINE + this.GUI_HEIGHT_EST > B) {
-                targetY := cY - this.GUI_HEIGHT_EST - this.OFFSET_SCREEN
-            } else {
-                targetY := cY + this.OFFSET_LINE
-            }
-        } else {
-            MouseGetPos(&mX, &mY)
-            targetX := mX + this.OFFSET_MOUSE
-            targetY := mY + this.OFFSET_MOUSE
-        }
-
-        this._EnsureInScreen(&targetX, &targetY, this.GUI_WIDTH, this.GUI_HEIGHT_EST)
-        this.GuiObj.Show("x" . targetX . " y" . targetY)
+        this.GuiObj.Show("x" . centerX . " y" . centerY)
         this.EditTrig.Focus()
     }
 

--- a/ui/Navi.ahk
+++ b/ui/Navi.ahk
@@ -23,6 +23,7 @@ class Navi {
     ; --- クラス定数 ---
     static GUI_WIDTH := 450
     static GUI_HEIGHT_APPROX := 540
+    static WINDOW_FRAME_WIDTH := 14  ; ウィンドウフレーム補正値（Win10/11標準テーマ）
     static IniPath := A_ScriptDir "\ui\Navi.ini"
     static ExplorerPath := ""
     static TOOLTIP_ERROR_DURATION := 2000
@@ -154,26 +155,18 @@ class Navi {
             }
         }
 
-        CoordMode "Caret", "Screen"
+        ; マウスカーソルがあるモニタの作業領域中央に配置
         CoordMode "Mouse", "Screen"
-        targetX := 0, targetY := 0
+        MouseGetPos(&mX, &mY)
+        monitorNum := this._GetMonitorFromPos(mX, mY)
+        MonitorGetWorkArea(monitorNum, &waL, &waT, &waR, &waB)
 
-        if CaretGetPos(&cX, &cY) {
-            targetX := cX + this.CARET_OFFSET_X
-            monitorNum := this._GetMonitorFromPos(cX, cY)
-            MonitorGetWorkArea(monitorNum, &L, &T, &R, &B)
-            if (cY + this.CARET_GAP_Y + this.GUI_HEIGHT_APPROX > B) {
-                targetY := cY - this.GUI_HEIGHT_APPROX - this.SCREEN_MARGIN
-            } else {
-                targetY := cY + this.CARET_GAP_Y
-            }
-        } else {
-            MouseGetPos(&mX, &mY)
-            targetX := mX + this.MOUSE_OFFSET, targetY := mY + this.MOUSE_OFFSET
-        }
+        winW := this.GUI_WIDTH + this.WINDOW_FRAME_WIDTH
+        winH := this.GUI_HEIGHT_APPROX
+        centerX := waL + (waR - waL - winW) // 2
+        centerY := waT + (waB - waT - winH) // 2
 
-        this._EnsureInScreen(&targetX, &targetY, this.GUI_WIDTH, this.GUI_HEIGHT_APPROX)
-        this.GuiObj.Show("x" . targetX . " y" . targetY)
+        this.GuiObj.Show("x" . centerX . " y" . centerY)
     }
 
     /**

--- a/ui/TempMemo.ahk
+++ b/ui/TempMemo.ahk
@@ -22,6 +22,7 @@ class TempMemo {
     static TAB_NAMES := ["Memo 1", "Memo 2", "Memo 3", "Work"]
     static GUI_WIDTH_DEFAULT := 600
     static GUI_HEIGHT_DEFAULT := 450
+    static WINDOW_FRAME_WIDTH := 14  ; ウィンドウフレーム補正値（Win10/11標準テーマ）
 
     static GuiObj := ""
     static TabObj := ""
@@ -48,42 +49,18 @@ class TempMemo {
             return
         }
 
-        ; 表示位置の計算
-        CoordMode "Caret", "Screen"
+        ; マウスカーソルがあるモニタの作業領域中央に配置
         CoordMode "Mouse", "Screen"
+        MouseGetPos(&mX, &mY)
+        monitorNum := this._GetMonitorFromPos(mX, mY)
+        MonitorGetWorkArea(monitorNum, &waL, &waT, &waR, &waB)
 
-        ; 現在のウィンドウサイズを取得（未表示時はデフォルト値を使用）
-        this.GuiObj.Opt("+LastFound")
-        hWnd := WinExist()
-        WinGetPos(, , &curW, &curH, hWnd)
-        realW := (curW > 0) ? curW : this.GUI_WIDTH_DEFAULT
-        realH := (curH > 0) ? curH : this.GUI_HEIGHT_DEFAULT
+        winW := this.GUI_WIDTH_DEFAULT + this.WINDOW_FRAME_WIDTH
+        winH := this.GUI_HEIGHT_DEFAULT
+        centerX := waL + (waR - waL - winW) // 2
+        centerY := waT + (waB - waT - winH) // 2
 
-        targetX := 0
-        targetY := 0
-
-        if CaretGetPos(&cX, &cY) {
-            targetX := cX + 5
-            monitorNum := this._GetMonitorFromPos(cX, cY)
-            MonitorGetWorkArea(monitorNum, &L, &T, &R, &B)
-
-            ; 画面下端にはみ出る場合は、キャレットの上側に表示（反転）
-            if (cY + 25 + realH > B) {
-                targetY := cY - realH - 10
-            } else {
-                targetY := cY + 25
-            }
-        } else {
-            ; キャレット座標が取得できない場合はマウス位置を基準にする
-            MouseGetPos(&mX, &mY)
-            targetX := mX + 15
-            targetY := mY + 15
-        }
-
-        ; 画面外へのはみ出し防止
-        this._EnsureInScreen(&targetX, &targetY, realW, realH)
-
-        this.GuiObj.Show("x" . targetX . " y" . targetY)
+        this.GuiObj.Show("x" . centerX . " y" . centerY)
 
         ; フォーカス処理
         if (this.EditObjs.Length >= this.TabObj.Value) {


### PR DESCRIPTION
## Summary
Display GUI windows (Navi, HotstringManager, TempMemo) at the center of the monitor where the mouse cursor is located.

## Checklist
- [x] Windows appear centered on the active monitor