### PR TITLE
feat/navi enhancements

### DIFF
--- a/ui/Navi.ahk
+++ b/ui/Navi.ahk
@@ -59,6 +59,7 @@ class Navi {
     static QuickPathHwnd := 0
     static FilesShown := Map()
     static lastSelectedId := 0  ; パンくず更新用
+    static DetailListGuiObj := ""  ; 詳細リストウィンドウ
 
     ; ---- Action registry ----
     static Actions := Map()  ; key(lower) => {label, run: (path)=>void}
@@ -141,7 +142,7 @@ class Navi {
         ; ステータスバーによる操作案内
         this.GuiObj.SetFont("s7")
         sb := this.GuiObj.Add("StatusBar")
-        sb.SetText(" [Space] アクションメニューを表示   /   [Enter] エクスプローラー  /   [Ctrl + Enter] ファイル表示   /  [Ctrl+P] ピン留め")
+        sb.SetText(" [Space]メニュー  [Enter]開く  [Ctrl+D]詳細  [F1]ヘルプ")
 
         rootDDL.OnEvent("Change", (*) => (
             this.lastRoot := rootDDL.Text,
@@ -159,6 +160,8 @@ class Navi {
         Hotkey("Enter", (*) => this._HandleEnter(), "On")
         Hotkey("^Enter", (*) => this.ToggleFilesUnderSelection(), "On")
         Hotkey("^p", (*) => (this.GuiObj["PinCheck"].Value := !this.GuiObj["PinCheck"].Value), "On")
+        Hotkey("^d", (*) => this.ShowDetailList(), "On")
+        Hotkey("F1", (*) => this._ShowHelp(), "On")
         Hotkey("Esc", (*) => this._DestroyGui(), "On")
         HotIf()
 
@@ -325,6 +328,33 @@ class Navi {
             this.GuiObj.Destroy()
             this.GuiObj := ""
         }
+    }
+
+    /**
+     * ショートカット一覧ヘルプを表示
+     */
+    static _ShowHelp() {
+        helpText := "
+        (
+        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+              Navi - ショートカット一覧
+        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+        【基本操作】
+          Space         アクションメニューを表示
+          Enter         エクスプローラーで開く
+          Esc           ウィンドウを閉じる
+
+        【表示切替】
+          Ctrl+Enter    ファイル表示トグル
+          Ctrl+D        詳細リスト表示
+
+        【その他】
+          Ctrl+P        ピン留めトグル
+          F1            このヘルプを表示
+        )"
+
+        MsgBox(helpText, "Navi ショートカット", "Iconi 4096")
     }
 
     static _ExecuteAction(key, path) {
@@ -798,6 +828,257 @@ class Navi {
         }
         this.FilesShown[id] := shown
         ToolTip("Files shown: " . count), SetTimer(() => ToolTip(), -this.TOOLTIP_SUCCESS_DURATION)
+    }
+
+    /**
+     * 選択中のファイル・フォルダと同一階層の詳細リストを表示
+     */
+    static ShowDetailList() {
+        if !(this.GuiObj && WinExist(this.GuiObj))
+            return
+
+        ; 既に詳細リストウィンドウが表示されている場合は閉じる
+        if (this.DetailListGuiObj && WinExist(this.DetailListGuiObj)) {
+            this._CloseDetailListGui()
+            return
+        }
+
+        tv := this.GuiObj["FolderTree"]
+        id := tv.GetSelection()
+        if (id = 0) {
+            ToolTip("フォルダを選択してください")
+            SetTimer(() => ToolTip(), -this.TOOLTIP_ERROR_DURATION)
+            return
+        }
+
+        selectedPath := this._GetTVFullPath(tv, id)
+
+        ; フォルダでない場合は親フォルダを取得
+        targetDir := ""
+        if (DirExist(selectedPath)) {
+            targetDir := selectedPath
+        } else if (FileExist(selectedPath)) {
+            SplitPath(selectedPath, , &parentDir)
+            targetDir := parentDir
+        } else {
+            ToolTip("パスが見つかりません")
+            SetTimer(() => ToolTip(), -this.TOOLTIP_ERROR_DURATION)
+            return
+        }
+
+        ; 詳細リスト用のGUIを作成
+        this.GuiObj.GetPos(&gx, &gy, &gw, &gh)
+        this.GuiObj.Opt("+Disabled")
+
+        dlGui := Gui("+Owner" . this.GuiObj.Hwnd . " +Resize", "詳細リスト - " . targetDir)
+        this.DetailListGuiObj := dlGui
+        dlGui.SetFont("s10", "Segoe UI")
+
+        ; ListViewを作成（名前、種類、サイズ、作成日時、更新日時）
+        lv := dlGui.Add("ListView", "r20 w900 Grid Sort", ["名前", "種類", "サイズ", "作成日時", "更新日時"])
+
+        ; 同一階層のすべてのファイル・フォルダを取得
+        itemCount := 0
+        ; フォルダを先に追加
+        loop files, targetDir . "\*", "D" {
+            if (SubStr(A_LoopFileName, 1, 1) == "." || InStr(A_LoopFileAttrib, "H"))
+                continue
+
+            created := FormatTime(A_LoopFileTimeCreated, "yyyy/MM/dd HH:mm:ss")
+            modified := FormatTime(A_LoopFileTimeModified, "yyyy/MM/dd HH:mm:ss")
+
+            lv.Add(, A_LoopFileName, "<フォルダ>", "", created, modified)
+            itemCount++
+        }
+
+        ; ファイルを追加
+        loop files, targetDir . "\*", "F" {
+            if (InStr(A_LoopFileAttrib, "H"))
+                continue
+
+            ; ファイルサイズを適切な単位で表示
+            size := A_LoopFileSize
+            sizeStr := ""
+            if (size < 1024)
+                sizeStr := size . " B"
+            else if (size < 1048576)
+                sizeStr := Round(size / 1024, 2) . " KB"
+            else if (size < 1073741824)
+                sizeStr := Round(size / 1048576, 2) . " MB"
+            else
+                sizeStr := Round(size / 1073741824, 2) . " GB"
+
+            ; ファイル種類（拡張子）
+            SplitPath(A_LoopFileName, , , &ext)
+            fileType := (ext != "") ? "." . ext : "ファイル"
+
+            created := FormatTime(A_LoopFileTimeCreated, "yyyy/MM/dd HH:mm:ss")
+            modified := FormatTime(A_LoopFileTimeModified, "yyyy/MM/dd HH:mm:ss")
+
+            lv.Add(, A_LoopFileName, fileType, sizeStr, created, modified)
+            itemCount++
+        }
+
+        ; 列幅の自動調整
+        lv.ModifyCol(1, 250)  ; 名前
+        lv.ModifyCol(2, 100)  ; 種類
+        lv.ModifyCol(3, 100)  ; サイズ
+        lv.ModifyCol(4, 180)  ; 作成日時
+        lv.ModifyCol(5, 180)  ; 更新日時
+
+        ; ステータスバー
+        dlGui.SetFont("s8")
+        sb := dlGui.Add("StatusBar")
+        sb.SetText(" [Space] アクションメニュー  /  [Enter] エクスプローラー  /  項目数: " . itemCount)
+
+        ; 閉じるボタン
+        dlGui.SetFont("s10")
+        btnClose := dlGui.Add("Button", "w100 Default", "閉じる")
+        btnClose.OnEvent("Click", (*) => this._CloseDetailListGui())
+
+        ; ListViewイベント
+        lv.OnEvent("DoubleClick", (obj, row) => (row ? this._ExecuteFromDetailList(dlGui, lv, row, targetDir, "e") : 0))
+
+        ; ホットキー設定（詳細リストウィンドウアクティブ時のみ）
+        HotIfWinActive("ahk_id " dlGui.Hwnd)
+        Hotkey("Space", (*) => this._ShowDetailListActionMenu(dlGui, lv, targetDir), "On")
+        Hotkey("Enter", (*) => this._ExecuteFromDetailList(dlGui, lv, lv.GetNext(), targetDir, "e"), "On")
+        Hotkey("^d", (*) => this._CloseDetailListGui(), "On")
+        Hotkey("Esc", (*) => this._CloseDetailListGui(), "On")
+        HotIf()
+
+        dlGui.OnEvent("Close", (*) => this._CloseDetailListGui())
+
+        ; ウィンドウを親ウィンドウの右側に表示
+        dlGui.Show("x" . (gx + gw + 10) . " y" . gy . " w920")
+    }
+
+    /**
+     * 詳細リストからアクションメニューを表示
+     */
+    static _ShowDetailListActionMenu(dlGui, lv, targetDir) {
+        row := lv.GetNext()
+        if (row == 0) {
+            ToolTip("項目を選択してください")
+            SetTimer(() => ToolTip(), -this.TOOLTIP_ERROR_DURATION)
+            return
+        }
+
+        itemName := lv.GetText(row, 1)
+        fullPath := targetDir . "\" . itemName
+
+        if (!DirExist(fullPath) && !FileExist(fullPath)) {
+            ToolTip("パスが見つかりません")
+            SetTimer(() => ToolTip(), -this.TOOLTIP_ERROR_DURATION)
+            return
+        }
+
+        dlGui.GetPos(&gx, &gy, &gw, &gh)
+        dlGui.Opt("+Disabled")
+
+        actGui := Gui("+Owner" . dlGui.Hwnd . " -Caption +AlwaysOnTop +Border")
+        actGui.BackColor := this.MENU_BG_COLOR
+        actGui.MarginX := 10
+        actGui.MarginY := 15
+
+        actGui.SetFont("s11 w700 cWhite", "Segoe UI")
+        actGui.Add("Text", "Center w" . this.MENU_BTN_W, "Selected: " . itemName)
+
+        actGui.SetFont("s10 w400")
+        ; レジストリに登録されたアクションからボタンを生成
+        keys := []
+        for k, _ in this.Actions
+            keys.Push(k)
+        ; ソート
+        if (keys.Length > 1) {
+            tmp := ""
+            for _, kk in keys
+                tmp .= kk . "`n"
+            tmp := Sort(RTrim(tmp, "`n"))
+            keys := StrSplit(tmp, "`n")
+        }
+
+        for k in keys {
+            act := this.Actions[k]
+            btn := actGui.Add("Button", "w" . this.MENU_BTN_W . " h" . this.MENU_BTN_H . " xm", act.label)
+            btn.OnEvent("Click", ((kk, *) => (
+                dlGui.Opt("-Disabled"),
+                actGui.Destroy(),
+                this._ExecuteFromDetailList(dlGui, lv, row, targetDir, kk)
+            )).Bind(k))
+        }
+
+        btnCancel := actGui.Add("Button", "w" . this.MENU_BTN_W . " h" . this.MENU_BTN_H . " xm y+12", "&X: Cancel")
+        btnCancel.OnEvent("Click", (*) => (dlGui.Opt("-Disabled"), actGui.Destroy()))
+        actGui.OnEvent("Escape", (*) => (dlGui.Opt("-Disabled"), actGui.Destroy()))
+
+        actGui.Show("AutoSize x" . gx + (gw - this.MENU_WIDTH) // 2 . " y" . gy + (gh - this.MENU_OFFSET_Y) // 2)
+    }
+
+    /**
+     * 詳細リストから選択されたアイテムに対してアクションを実行
+     */
+    static _ExecuteFromDetailList(dlGui, lv, row, targetDir, key) {
+        if (row == 0) {
+            ToolTip("項目を選択してください")
+            SetTimer(() => ToolTip(), -this.TOOLTIP_ERROR_DURATION)
+            return
+        }
+
+        itemName := lv.GetText(row, 1)
+        fullPath := targetDir . "\" . itemName
+
+        if (!DirExist(fullPath) && !FileExist(fullPath)) {
+            ToolTip("パスが見つかりません")
+            SetTimer(() => ToolTip(), -this.TOOLTIP_ERROR_DURATION)
+            return
+        }
+
+        ; 操作したパスとルート名をメモリに保存（ツリーと同じように）
+        this.lastPath := fullPath
+        if (this.GuiObj && WinExist(this.GuiObj)) {
+            this.lastRoot := this.GuiObj["RootDDL"].Text
+        }
+
+        this._ExecuteAction(key, fullPath)
+
+        ; アクション実行後に詳細リストウィンドウを閉じる
+        this._CloseDetailListGui()
+
+        ; メインのNaviウィンドウも閉じる（ピン留めとShiftキーを考慮）
+        if (this.GuiObj && WinExist(this.GuiObj)) {
+            k := StrLower(key)
+            ; 検索アクション(f)以外の場合
+            if (k != "f") {
+                ; ピン留めされていない、かつShiftキーが押されていない場合に閉じる
+                if (!this.GuiObj["PinCheck"].Value && !GetKeyState("Shift", "P")) {
+                    this._DestroyGui()
+                }
+            }
+        }
+
+        if (key != "k" && StrLower(key) != "f") {
+            ToolTip("実行 [" . key . "]: " . fullPath)
+            SetTimer(() => ToolTip(), -this.TOOLTIP_SUCCESS_DURATION)
+        }
+    }
+
+    /**
+     * 詳細リストウィンドウを閉じる
+     */
+    static _CloseDetailListGui() {
+        if (this.DetailListGuiObj && WinExist(this.DetailListGuiObj)) {
+            try this.DetailListGuiObj.Destroy()
+            this.DetailListGuiObj := ""
+        }
+        if (this.GuiObj && WinExist(this.GuiObj)) {
+            this.GuiObj.Opt("-Disabled")
+            ; ツリーにフォーカスを戻す
+            try {
+                tv := this.GuiObj["FolderTree"]
+                tv.Focus()
+            }
+        }
     }
 
     /**

--- a/ui/Navi.ahk
+++ b/ui/Navi.ahk
@@ -803,6 +803,7 @@ class Navi {
     /**
      * 選択ファイルをNaviと同階層(ui)の一時フォルダにコピーし、既定アプリで開く
      * ファイル名に TEMP_YYYYMMDD-HHMMSS_ の接頭辞を付与
+     * ショートカット(.lnk)の場合は、ショートカットの先のファイルをコピー
      */
     static _OpenTempCopy(path) {
         tempDir := A_ScriptDir . this.TEMP_DIR_SUBPATH
@@ -826,11 +827,32 @@ class Navi {
             SetTimer(() => ToolTip(), -this.TOOLTIP_ERROR_DURATION)
             return
         }
-        SplitPath(path, &fileName)
+
+        ; ショートカットファイルの場合は先のファイルを取得
+        actualPath := path
+        SplitPath(path, , , &ext)
+        if (StrLower(ext) == "lnk") {
+            try {
+                FileGetShortcut(path, &targetPath)
+                if (targetPath != "" && FileExist(targetPath)) {
+                    actualPath := targetPath
+                } else {
+                    ToolTip("ショートカットの先が見つかりません")
+                    SetTimer(() => ToolTip(), -this.TOOLTIP_ERROR_DURATION)
+                    return
+                }
+            } catch as e {
+                ToolTip("ショートカットの解決に失敗: " . e.Message)
+                SetTimer(() => ToolTip(), -this.TOOLTIP_ERROR_DURATION)
+                return
+            }
+        }
+
+        SplitPath(actualPath, &fileName)
         ts := FormatTime(, "yyyyMMdd-HHmmss") ; YYYYMMDD-HHMMSS
         dest := tempDir . "\" . this.TEMP_PREFIX . ts . "_" . fileName
         try {
-            FileCopy(path, dest, true)
+            FileCopy(actualPath, dest, true)
             Run('"' . dest . '"')
             ToolTip("Temp copy opened: " . dest)
             SetTimer(() => ToolTip(), -this.TOOLTIP_SUCCESS_DURATION)


### PR DESCRIPTION
## Summary
Add shortcut (.lnk) resolution for temp copy and detail list view (Ctrl+D) for browsing files with timestamps.

## Checklist
 - [x] Resolve .lnk shortcut to actual file in temp copy
 - [x] Detail list shows name, type, size, created/modified dates
 - [x] Action menu support in detail list
 - [x] F1 help dialog with keyboard shortcuts