### PR TITLE
feat(navi): filter-matched folders can now be expanded to browse their contents

### DIFF
--- a/ui/navi/Navi.Filter.ahk
+++ b/ui/navi/Navi.Filter.ahk
@@ -375,6 +375,10 @@ class NaviFilter {
                         ; 既存ノードが今回の結果ではマッチノードになる場合は着色対象に追加
                         if (isMatch && !this._FilterMatchIdSet.Has(existingID))
                             this._FilterMatchIdSet[existingID] := true
+                        ; このノードに実の子が追加される: プレースホルダーのみなら削除
+                        firstChild := tv.GetChild(existingID)
+                        if (firstChild != 0 && tv.GetText(firstChild) == "...loading..." && tv.GetNext(firstChild) == 0)
+                            tv.Delete(firstChild)
                         parentID := existingID
                     } else {
                         opts := isMatch ? "Bold" : ""
@@ -383,8 +387,10 @@ class NaviFilter {
                             firstMatch := false
                         }
                         nodeID := tv.Add(part, parentID, opts . " Icon1")
-                        if (isMatch)
+                        if (isMatch) {
                             this._FilterMatchIdSet[nodeID] := true
+                            tv.Add("...loading...", nodeID)  ; ノード作成直後に追加して展開ボタンを即表示
+                        }
                         addedPaths[key] := nodeID
                         parentID        := nodeID
                     }
@@ -393,9 +399,12 @@ class NaviFilter {
                 if (Mod(idx, 50) = 0)
                     Sleep(0)
             }
-            ; 子を持つノードを展開（Add 時点では子がないため "Expand" が無効なため後処理）
+            ; 子を持つノードを展開（"...loading..." プレースホルダーのみのノードは展開しない）
             for _, nodeID in addedPaths {
-                if (nodeID != rootID && tv.GetChild(nodeID) != 0)
+                if (nodeID == rootID)
+                    continue
+                child := tv.GetChild(nodeID)
+                if (child != 0 && tv.GetText(child) != "...loading...")
                     tv.Modify(nodeID, "Expand")
             }
             this.EnsureFilterDraw(tv)

--- a/ui/navi/Navi.ahk
+++ b/ui/navi/Navi.ahk
@@ -910,13 +910,38 @@ class Navi {
 
     static _OnItemExpand(tv, id) {
         child := tv.GetChild(id)
-        if (child == 0 || tv.GetText(child) != "...loading...") {
+        if (child != 0 && tv.GetText(child) == "...loading...") {
+            tv.Delete(child)
+            this._LoadSub(tv, this._GetTVFullPath(tv, id), id)
+            ; ファイル表示モードがONなら展開と同時にファイルも自動表示
+            this._ShowFilesIfEnabled(tv, id, this._GetTVFullPath(tv, id))
             return
         }
-        tv.Delete(child)
-        this._LoadSub(tv, this._GetTVFullPath(tv, id), id)
-        ; ファイル表示モードがONなら展開と同時にファイルも自動表示
-        this._ShowFilesIfEnabled(tv, id, this._GetTVFullPath(tv, id))
+        ; フィルタ中は未ロードの子フォルダを動的追加
+        if (NaviFilter._FilterMatchIdSet.Count > 0)
+            this._LoadFilterSub(tv, id)
+    }
+
+    ; フィルタ中: フィルタツリーに未追加の子フォルダを動的に追加する
+    static _LoadFilterSub(tv, parentID) {
+        fullPath := this._GetTVFullPath(tv, parentID)
+        if (!DirExist(fullPath))
+            return
+        ; 既存の子ノード名を収集（フィルタ結果として既に追加済みのもの）
+        existing := Map()
+        childID := tv.GetChild(parentID)
+        while (childID != 0) {
+            existing[StrLower(tv.GetText(childID))] := true
+            childID := tv.GetNext(childID)
+        }
+        ; 未追加のサブフォルダを追加（通常ツリーと同じ lazy expand 形式で）
+        loop files, fullPath . "\*", "D" {
+            if (SubStr(A_LoopFileName, 1, 1) == "." || InStr(A_LoopFileAttrib, "H"))
+                continue
+            if (!existing.Has(StrLower(A_LoopFileName)))
+                tv.Add("...loading...", tv.Add(A_LoopFileName, parentID, "Icon1"))
+        }
+        this._ShowFilesIfEnabled(tv, parentID, fullPath)
     }
 
     static _ShowFilesIfEnabled(tv, nodeID, fullPath) {


### PR DESCRIPTION
## Summary

- Filter-matched folders can now be expanded to browse their contents
  - Clicking the expand button loads subfolders lazily from the filesystem
  - Folders not matched by the filter are also accessible once expanded

## Checklist

- [x] Filter a folder and confirm the expand button is visible on matched folders
- [x] Expand a matched folder and confirm its subfolders are loaded correctly
- [x] Expand a matched folder and confirm non-matched subfolders are also shown