### PR TITLE
feat(navi): jump between filter-matched folders with F3 / Shift+F3

### DIFF
--- a/ui/navi/Navi.Filter.ahk
+++ b/ui/navi/Navi.Filter.ahk
@@ -496,4 +496,38 @@ class NaviFilter {
             }
         }
     }
+
+    /**
+     * フィルタマッチノード間を F3 / Shift+F3 でジャンプ
+     * dir: +1=次, -1=前
+     */
+    static JumpToMatch(tv, dir) {
+        if (this._FilterMatchIdSet.Count == 0)
+            return
+        ; ツリー順にマッチノードを収集
+        matches := []
+        id := tv.GetNext(0, "Full")
+        while (id != 0) {
+            if (this._FilterMatchIdSet.Has(id))
+                matches.Push(id)
+            id := tv.GetNext(id, "Full")
+        }
+        if (matches.Length == 0)
+            return
+        ; 現在の選択位置を探す
+        selID  := tv.GetSelection()
+        curIdx := 0
+        for i, mid in matches {
+            if (mid == selID) {
+                curIdx := i
+                break
+            }
+        }
+        ; 循環ジャンプ
+        if (dir > 0)
+            nextIdx := (curIdx == 0 || curIdx >= matches.Length) ? 1 : curIdx + 1
+        else
+            nextIdx := (curIdx <= 1) ? matches.Length : curIdx - 1
+        tv.Modify(matches[nextIdx], "Select Vis")
+    }
 }

--- a/ui/navi/Navi.Search.ahk
+++ b/ui/navi/Navi.Search.ahk
@@ -1206,6 +1206,11 @@ class NaviSearch {
             return
         lv := this.JumpListView
         if !IsObject(lv) || lv.GetCount() = 0 {
+            ; 検索結果がなければフィルタジャンプへフォールバック
+            if (NaviFilter._FilterMatchIdSet.Count > 0) {
+                NaviFilter.JumpToMatch(navi.GuiObj["FolderTree"], delta)
+                return
+            }
             ToolTip("ヒットなし")
             SetTimer(() => ToolTip(), -navi.TOOLTIP_SUCCESS_DURATION)
             return

--- a/ui/navi/Navi.ahk
+++ b/ui/navi/Navi.ahk
@@ -262,6 +262,8 @@ class Navi {
         Hotkey("^p", (*) => (this.GuiObj["PinCheck"].Value := !this.GuiObj["PinCheck"].Value), "On")
         Hotkey("^d", (*) => NaviDetailList.Show(), "On")
         Hotkey("^f", (*) => this.GuiObj["TreeFilter"].Focus(), "On")
+        Hotkey("F3",  (*) => NaviFilter.JumpToMatch(this.GuiObj["FolderTree"], +1), "On")
+        Hotkey("+F3", (*) => NaviFilter.JumpToMatch(this.GuiObj["FolderTree"], -1), "On")
         Hotkey("F1", (*) => this._ShowHelp(), "On")
         Hotkey("Esc", (*) => this._HandleEsc(), "On")
         Hotkey("~Down", (*) => this._HandleRootBtnDown(), "On")


### PR DESCRIPTION
## Summary

- F3 / Shift+F3 to jump between filter-matched folders (wraps around)
- Falls back to filter jump when F3 is pressed with no search results

## Checklist

- [x] Filter a folder and confirm F3 jumps to the next matched folder
- [x] Confirm Shift+F3 jumps to the previous matched folder
- [x] Confirm wrapping works at the first and last match
- [x] Confirm F3 falls back to filter jump when search has no results