### PR TITLE
fix(navi): F3 on filter input jumps to first match instead of second

### DIFF
--- a/ui/navi/Navi.Filter.ahk
+++ b/ui/navi/Navi.Filter.ahk
@@ -514,8 +514,8 @@ class NaviFilter {
         }
         if (matches.Length == 0)
             return
-        ; 現在の選択位置を探す
-        selID  := tv.GetSelection()
+        ; 現在の選択位置を探す（フィルタ入力中は先頭からスタート）
+        selID  := this._navi._TreeFilterFocused ? 0 : tv.GetSelection()
         curIdx := 0
         for i, mid in matches {
             if (mid == selID) {
@@ -529,5 +529,6 @@ class NaviFilter {
         else
             nextIdx := (curIdx <= 1) ? matches.Length : curIdx - 1
         tv.Modify(matches[nextIdx], "Select Vis")
+        tv.Focus()
     }
 }


### PR DESCRIPTION
## Summary

- F3 now focuses the TreeView after jumping to a filter-matched folder
- F3 pressed while typing in the filter input now jumps to the first match instead of the second

## Checklist

- [x] Press F3 after filtering and confirm the TreeView has keyboard focus
- [x] Confirm arrow keys and Enter work immediately after F3 jump
- [x] Confirm F3 while typing in the filter input jumps to the first match