### PR TITLE
Feat/snapai result html

### DIFF
--- a/modules/ImeControl.ahk
+++ b/modules/ImeControl.ahk
@@ -36,8 +36,11 @@ class ImeControl {
     }
 
     static SetOpenStatus(open := true, hwnd := 0) {
-        if !hwnd
-            hwnd := WinGetID("A")
+        if !hwnd {
+            try hwnd := WinGetID("A")
+            if !hwnd
+                return false
+        }
 
         try
             hwndFocus := ControlGetHwnd(ControlGetFocus("ahk_id " hwnd), "ahk_id " hwnd)

--- a/ui/SnapAI.ahk
+++ b/ui/SnapAI.ahk
@@ -8,15 +8,14 @@
 ; Version:      1.0.0
 ; License:      MIT
 ;
-; Usage Example (Main.ahk):
-;   #Include "ui\SnapAI.ahk"
-;   SnapAI.Init()
-;   #HotIf GetKeyState("vk1D", "P")   ; 無変換キーを押しながら
-;   t:: SnapAI.Show()
-;   #HotIf
+; Usage:
+;   SnapAI.ahk を直接実行してください（スタートアップ登録推奨）
+;   ホットキーはファイル末尾で変更できます
 ;
 ; ==============================================================================
 #Requires AutoHotkey v2.0
+#SingleInstance Force
+SetWorkingDir A_ScriptDir
 
 class SnapAI {
     static GuiObj := ""
@@ -1131,3 +1130,13 @@ class SnapAI {
         return str
     }
 }
+
+; ============================================================
+; エントリーポイント
+; ============================================================
+SnapAI.Init()
+
+; ホットキー（好みに応じて変更してください）
+#HotIf GetKeyState("vk1D", "P")
+t:: SnapAI.Show()
+#HotIf

--- a/ui/SnapAI.ahk
+++ b/ui/SnapAI.ahk
@@ -25,12 +25,19 @@ class SnapAI {
     static ApiKey := ""
     static ApiEndpoint := ""
     static _pendingText := ""
+    static _lastResult := ""
+    static _lastPrompt := ""
+    static _lastInputText := ""
     static _whr := ""
     static _pollFn := ""
     static GUI_WIDTH := 500
     static GUI_HEIGHT := 350
-    static IniVersion := 2      ; INIスキーマのバージョン。設定項目追加時にインクリメント
+    static _resultWinW := 500
+    static _resultWinH := 350
+    static IniVersion := 4      ; INIスキーマのバージョン。設定項目追加時にインクリメント
     static AutoCopy := false
+    static CloseOnFocusLost := false
+    static _focusLostFn := ""
     static _startTime := 0
     static _progressGui := ""
     static _progressBar := ""
@@ -48,8 +55,8 @@ class SnapAI {
             IniWrite("2000",                                                this.IniPath, "Settings", "MaxTokens")
             IniWrite(this.IniVersion,                                       this.IniPath, "Settings", "Version")
             IniWrite("0",                                                   this.IniPath, "Settings", "AutoCopy")
-            IniWrite("プロの翻訳者として、入力テキストを自然な英語に翻訳してください。翻訳文のみを返し、説明・注釈は不要です。",                                      this.IniPath, "Prompts", "1.翻訳（日→英）")
-            IniWrite("プロの翻訳者として、入力テキストを自然な日本語に翻訳してください。翻訳文のみを返し、説明・注釈は不要です。",                                      this.IniPath, "Prompts", "2.翻訳（英→日）")
+            IniWrite("プロの翻訳者として、入力テキストを自然な英語に翻訳してください。翻訳文のみを返してください。出力形式のルール：「- 」で始まる行は翻訳後も必ず「- 」で始めること。「## 」「# 」で始まる行は翻訳後も同じ記号を付けること。",  this.IniPath, "Prompts", "1.翻訳（日→英）")
+            IniWrite("プロの翻訳者として、入力テキストを自然な日本語に翻訳してください。翻訳文のみを返してください。出力形式のルール：「- 」で始まる行は翻訳後も必ず「- 」で始めること。「## 」「# 」で始まる行は翻訳後も同じ記号を付けること。",  this.IniPath, "Prompts", "2.翻訳（英→日）")
             IniWrite("以下のテキストを日本語で3〜5つの箇条書きに要約してください。各ポイントは1〜2文で簡潔にまとめ、要約のみを返してください。",                          this.IniPath, "Prompts", "3.要約")
             IniWrite("プロの校正者として、入力テキストの誤字・脱字・文法エラーを修正してください。修正後のテキストのみを返し、変更点の説明は不要です。",                    this.IniPath, "Prompts", "4.校正")
         } else {
@@ -69,13 +76,37 @@ class SnapAI {
                     if (IniRead(this.IniPath, "Settings", "AutoCopy", "") == "")
                         IniWrite("0", this.IniPath, "Settings", "AutoCopy")
                 }
+                if (storedVer < 3) {
+                    ; v3: 翻訳プロンプトにMarkdown書式保持の指示を追加（デフォルト文のまま未変更の場合のみ更新）
+                    mdSuffix := "箇条書き・見出しなどの書式はMarkdown（箇条書きは「- 」、見出しは「## 」）で保持してください。"
+                    oldJE := "プロの翻訳者として、入力テキストを自然な英語に翻訳してください。翻訳文のみを返し、説明・注釈は不要です。"
+                    oldEJ := "プロの翻訳者として、入力テキストを自然な日本語に翻訳してください。翻訳文のみを返し、説明・注釈は不要です。"
+                    if (IniRead(this.IniPath, "Prompts", "1.翻訳（日→英）", "") == oldJE)
+                        IniWrite(oldJE . mdSuffix, this.IniPath, "Prompts", "1.翻訳（日→英）")
+                    if (IniRead(this.IniPath, "Prompts", "2.翻訳（英→日）", "") == oldEJ)
+                        IniWrite(oldEJ . mdSuffix, this.IniPath, "Prompts", "2.翻訳（英→日）")
+                }
+                if (storedVer < 4) {
+                    ; v4: 翻訳プロンプトをより明示的なルール形式に変更
+                    newJE := "プロの翻訳者として、入力テキストを自然な英語に翻訳してください。翻訳文のみを返してください。出力形式のルール：「- 」で始まる行は翻訳後も必ず「- 」で始めること。「## 」「# 」で始まる行は翻訳後も同じ記号を付けること。"
+                    newEJ := "プロの翻訳者として、入力テキストを自然な日本語に翻訳してください。翻訳文のみを返してください。出力形式のルール：「- 」で始まる行は翻訳後も必ず「- 」で始めること。「## 」「# 」で始まる行は翻訳後も同じ記号を付けること。"
+                    v3JE := "プロの翻訳者として、入力テキストを自然な英語に翻訳してください。翻訳文のみを返し、説明・注釈は不要です。箇条書き・見出しなどの書式はMarkdown（箇条書きは「- 」、見出しは「## 」）で保持してください。"
+                    v3EJ := "プロの翻訳者として、入力テキストを自然な日本語に翻訳してください。翻訳文のみを返し、説明・注釈は不要です。箇条書き・見出しなどの書式はMarkdown（箇条書きは「- 」、見出しは「## 」）で保持してください。"
+                    curJE := IniRead(this.IniPath, "Prompts", "1.翻訳（日→英）", "")
+                    curEJ := IniRead(this.IniPath, "Prompts", "2.翻訳（英→日）", "")
+                    if (curJE == v3JE || curJE == "プロの翻訳者として、入力テキストを自然な英語に翻訳してください。翻訳文のみを返し、説明・注釈は不要です。")
+                        IniWrite(newJE, this.IniPath, "Prompts", "1.翻訳（日→英）")
+                    if (curEJ == v3EJ || curEJ == "プロの翻訳者として、入力テキストを自然な日本語に翻訳してください。翻訳文のみを返し、説明・注釈は不要です。")
+                        IniWrite(newEJ, this.IniPath, "Prompts", "2.翻訳（英→日）")
+                }
                 IniWrite(this.IniVersion, this.IniPath, "Settings", "Version")
             }
             ; 将来のバージョン追加時はここに if (storedVer < N) { ... } を続ける
         }
-        this.ApiKey      := IniRead(this.IniPath, "Settings", "ApiKey",      "")
-        this.ApiEndpoint := IniRead(this.IniPath, "Settings", "ApiEndpoint", "https://api.openai.com/v1/chat/completions")
-        this.AutoCopy    := IniRead(this.IniPath, "Settings", "AutoCopy",    "0") == "1"
+        this.ApiKey           := IniRead(this.IniPath, "Settings", "ApiKey",           "")
+        this.ApiEndpoint      := IniRead(this.IniPath, "Settings", "ApiEndpoint",      "https://api.openai.com/v1/chat/completions")
+        this.AutoCopy         := IniRead(this.IniPath, "Settings", "AutoCopy",         "0") == "1"
+        this.CloseOnFocusLost := IniRead(this.IniPath, "Settings", "CloseOnFocusLost", "0") == "1"
     }
 
     static _IsLocalEndpoint() {
@@ -110,6 +141,11 @@ class SnapAI {
             }
         } catch {
             mMenu.Add("1.翻訳", (ItemName, *) => this._Process("1.翻訳"))
+        }
+
+        if (this._pendingText != "") {
+            mMenu.Add()
+            mMenu.Add("カスタム...", (*) => this._ShowCustomPromptDialog())
         }
 
         mMenu.Add()
@@ -199,6 +235,43 @@ class SnapAI {
         this._Process(modeName, customPrompt)
     }
 
+    static _ShowCustomPromptDialog() {
+        dg := Gui("+AlwaysOnTop", "SnapAI - カスタムプロンプト")
+        dg.SetFont("s10", "Segoe UI")
+        dg.MarginX := 15
+        dg.MarginY := 12
+
+        dg.Add("Text", , "プロンプト:")
+        promptEdit := dg.Add("Edit", "w420 h100 Multi")
+
+        btnOk     := dg.Add("Button", "y+12 w140 Default", "OK  (Ctrl+Enter)")
+        btnCancel := dg.Add("Button", "x+10 w80", "キャンセル")
+
+        btnOk.OnEvent("Click",     (*) => this._ProcessCustomPrompt(dg, promptEdit))
+        btnCancel.OnEvent("Click", (*) => dg.Destroy())
+        dg.OnEvent("Close",        (*) => dg.Destroy())
+
+        HotIfWinActive("ahk_id " dg.Hwnd)
+        Hotkey("^Enter", (*) => this._ProcessCustomPrompt(dg, promptEdit), "On")
+        Hotkey("Escape", (*) => dg.Destroy(), "On")
+        HotIf()
+
+        dg.Show("AutoSize")
+        promptEdit.Focus()
+    }
+
+    static _ProcessCustomPrompt(dg, promptEdit) {
+        prompt := Trim(promptEdit.Value)
+        if (prompt == "") {
+            ToolTip("プロンプトを入力してください。")
+            SetTimer(() => ToolTip(), -2000)
+            promptEdit.Focus()
+            return
+        }
+        dg.Destroy()
+        this._Process("カスタム", prompt)
+    }
+
     static _Process(modeName, customPrompt := "") {
         targetText := this._pendingText
         this._pendingText := ""
@@ -236,6 +309,8 @@ class SnapAI {
         whr.Open("POST", this.ApiEndpoint, true)  ; true = 非同期
 
         this._SetRequestHeaders(whr)
+        this._lastPrompt    := prompt
+        this._lastInputText := text
         body := this._BuildRequestBody(prompt, text, model, temperature, maxTokens)
 
         ; 既存リクエストのタイマーをキャンセル
@@ -388,46 +463,383 @@ class SnapAI {
     }
 
     static _ShowResult(modeName, resultText) {
+        ; _PollResponse はタイマー文脈で呼ばれるため、ここでの Destroy() は安全
+        if (this.GuiObj) {
+            this.GuiObj.Destroy()
+            this.GuiObj := ""
+        }
+        this._lastResult := resultText
         if (this.AutoCopy) {
             A_Clipboard := resultText
             ToolTip("クリップボードにコピーしました", , , 3)
             SetTimer(() => ToolTip(, , , 3), -2000)
         }
-        this.GuiObj := Gui("+AlwaysOnTop +Resize", "AI Result: " . modeName)
-        this.GuiObj.SetFont("s11", "Segoe UI")
-        this.EditObj := this.GuiObj.Add("Edit", "Multi ReadOnly w" . this.GUI_WIDTH . " h" . this.GUI_HEIGHT,
-            resultText)
-        btnCopy := this.GuiObj.Add("Button", "w80", "コピー")
-        btnCopy.OnEvent("Click", (*) => this._CopyResult())
 
-        ; ウィンドウリサイズ時にEditとボタンを追従させる
-        editObj := this.EditObj
+        savedW := Integer(IniRead(this.IniPath, "ResultWindow", "W", this.GUI_WIDTH))
+        savedH := Integer(IniRead(this.IniPath, "ResultWindow", "H", this.GUI_HEIGHT))
+        this._resultWinW := savedW
+        this._resultWinH := savedH
+
+        this.GuiObj := Gui("+AlwaysOnTop +Resize", "AI Result: " . modeName)
+        this.GuiObj.MarginX := 10
+        this.GuiObj.MarginY := 10
+
+        wb := this.GuiObj.Add("ActiveX", "w" . savedW . " h" . savedH, "Shell.Explorer.2")
+        this.EditObj := wb
+
+        try {
+            this._SetHTML(wb.Value, this._BuildHTML(resultText))
+        } catch {
+            try {
+                plain := "<pre style='font-family:Segoe UI,sans-serif;padding:12px;line-height:1.6;white-space:pre-wrap'>"
+                    . this._HTMLEscape(resultText) . "</pre>"
+                this._SetHTML(wb.Value, plain)
+            }
+        }
+
+        followUpEdit := this.GuiObj.Add("Edit", "w" . (savedW - 90) . " h23 +0x100", "")
+        followUpEdit.SetFont("s10", "Segoe UI")
+        btnSend := this.GuiObj.Add("Button", "x+5 w80", "送信")
+        btnSend.OnEvent("Click", (*) => this._SubmitFollowUp(followUpEdit, btnSend))
+
+        btnCopy := this.GuiObj.Add("Button", "xm w80", "コピー")
+        btnCopy.OnEvent("Click", (*) => this._CopyResult(btnCopy))
+
+        wb2 := wb
+        fuEdit2 := followUpEdit
+        bSend2  := btnSend
         this.GuiObj.OnEvent("Size", (g, minmax, w, h) => (
             minmax != -1
-                ? (editObj.Move(, , w - 20, h - 50), btnCopy.Move(, h - 33))
+                ? (wb2.Move(, , w - 20, h - 80),
+                   fuEdit2.Move(, h - 63, w - 105),
+                   bSend2.Move(w - 90, h - 65),
+                   btnCopy.Move(, h - 35),
+                   this._resultWinW := w - 20,
+                   this._resultWinH := h - 80)
                 : 0
         ))
 
         CoordMode "Mouse", "Screen"
         MouseGetPos(&mX, &mY)
-        this.GuiObj.Show("x" . mX + 15 . " y" . mY + 15)
+        monIdx := MonitorGetPrimary()
+        loop MonitorGetCount() {
+            MonitorGet(A_Index, &mLeft, &mTop, &mRight, &mBottom)
+            if (mX >= mLeft && mX < mRight && mY >= mTop && mY < mBottom) {
+                monIdx := A_Index
+                break
+            }
+        }
+        MonitorGetWorkArea(monIdx, &waLeft, &waTop, &waRight, &waBottom)
+        winX := waLeft + ((waRight - waLeft) - (savedW + 20)) // 2
+        winY := waTop  + ((waBottom - waTop) - (savedH + 60)) // 2
+        this.GuiObj.Show("x" . winX . " y" . winY)
 
-        this.GuiObj.OnEvent("Close", (*) => (this.GuiObj := ""))
+        this.GuiObj.OnEvent("Close", (*) => this._OnResultClose())
 
-        ; Esc で閉じる（ウィンドウがアクティブな間のみ有効）
+        fuEdit3  := followUpEdit
+        bSend3   := btnSend
         HotIfWinActive("ahk_id " this.GuiObj.Hwnd)
-        Hotkey("Esc", (*) => this.GuiObj.Destroy(), "On")
+        Hotkey("Esc",     (*) => this.GuiObj.Destroy(), "On")
+        Hotkey("^w",      (*) => this.GuiObj.Destroy(), "On")
+        Hotkey("^Enter",  (*) => this._SubmitFollowUp(fuEdit3, bSend3), "On")
         HotIf()
+
+        if (this.CloseOnFocusLost) {
+            guiHwnd := this.GuiObj.Hwnd
+            this._focusLostFn := (wParam, _lParam, _msg, hwnd) => (
+                (wParam == 0 && hwnd == guiHwnd && IsObject(this.GuiObj))
+                    ? this.GuiObj.Destroy()
+                    : ""
+            )
+            OnMessage(0x0006, this._focusLostFn)
+        }
     }
 
-    static _CopyResult() {
-        A_Clipboard := this.EditObj.Value
-        ToolTip("コピーしました")
-        SetTimer(() => ToolTip(), -2000)
+    static _CopyResult(btnRef := "") {
+        A_Clipboard := this._lastResult
+        if (IsObject(btnRef)) {
+            btnRef.Text := "コピー済 ✓"
+            SetTimer(() => (IsObject(btnRef) ? btnRef.Text := "コピー" : ""), -1500)
+        } else {
+            ToolTip("コピーしました")
+            SetTimer(() => ToolTip(), -2000)
+        }
+    }
+
+    static _OnResultClose() {
+        IniWrite(this._resultWinW, this.IniPath, "ResultWindow", "W")
+        IniWrite(this._resultWinH, this.IniPath, "ResultWindow", "H")
+        if (this._focusLostFn != "") {
+            OnMessage(0x0006, this._focusLostFn, 0)
+            this._focusLostFn := ""
+        }
+        this.GuiObj := ""
+    }
+
+    static _SubmitFollowUp(followUpEdit, btnSend) {
+        text := Trim(followUpEdit.Value)
+        if (text == "")
+            return
+        ; result ウィンドウは触らない。_ShowResult（タイマー文脈）で安全に閉じる
+        followUpEdit.Enabled := false
+        btnSend.Enabled := false
+        this._ShowProgressGui("追加質問")
+        try {
+            this._StartFollowUpRequest(text)
+        } catch as e {
+            this._CancelRequest()
+            followUpEdit.Enabled := true
+            btnSend.Enabled := true
+            this._ShowError(e.Message)
+        }
+    }
+
+    static _StartFollowUpRequest(followUpText) {
+        model       := IniRead(this.IniPath, "Settings", "Model",       "gpt-4o-mini")
+        temperature := IniRead(this.IniPath, "Settings", "Temperature", "0.5")
+        maxTokens   := IniRead(this.IniPath, "Settings", "MaxTokens",   "2000")
+
+        whr := ComObject("WinHttp.WinHttpRequest.5.1")
+        whr.Open("POST", this.ApiEndpoint, true)
+        this._SetRequestHeaders(whr)
+
+        body := '{"model":"' . model . '","messages":['
+            . '{"role":"system","content":"'    . this._JSONEscape(this._lastPrompt)    . '"},'
+            . '{"role":"user","content":"'      . this._JSONEscape(this._lastInputText) . '"},'
+            . '{"role":"assistant","content":"' . this._JSONEscape(this._lastResult)    . '"},'
+            . '{"role":"user","content":"'      . this._JSONEscape(followUpText)        . '"}'
+            . '],"temperature":' . temperature . ',"max_tokens":' . maxTokens . '}'
+
+        if (this._pollFn != "") {
+            SetTimer(this._pollFn, 0)
+            this._pollFn := ""
+            this._whr := ""
+        }
+        try {
+            whr.Send(body)
+        } catch as e {
+            throw Error("送信エラー: " . e.Message)
+        }
+        this._startTime := A_TickCount
+        this._whr := whr
+        this._pollFn := () => this._PollResponse("追加質問")
+        SetTimer(this._pollFn, this.POLL_INTERVAL_MS)
+    }
+
+    static _SetHTML(wb, html) {
+        wb.Navigate("about:blank")
+        loop 100 {
+            if (wb.ReadyState == 4)
+                break
+            Sleep(20)
+        }
+        wb.Document.open()
+        wb.Document.write(html)
+        wb.Document.close()
+    }
+
+    static _BuildHTML(text) {
+        css := "body{margin:14px 18px;font-family:'Segoe UI',sans-serif;font-size:13px;line-height:1.75;color:#1a1a1a;background:#fafafa}"
+        css .= "h1{font-size:17px;font-weight:700;margin:14px 0 6px}"
+        css .= "h2{font-size:14px;font-weight:700;margin:12px 0 4px}"
+        css .= "ul,ol{margin:4px 0;padding-left:22px}li{margin:3px 0}"
+        css .= "ul ul,ol ol,ul ol,ol ul{margin:2px 0;padding-left:18px}"
+        css .= "p{margin:3px 0}"
+        css .= "code{font-family:'Courier New',monospace;font-size:12px;background:#ebebeb;padding:1px 5px;border-radius:3px}"
+        css .= "pre{background:#f0f0f0;border-left:3px solid #ccc;padding:10px 12px;margin:8px 0;overflow-x:auto}"
+        css .= "pre code{background:none;padding:0}"
+        css .= "hr{border:none;border-top:1px solid #ddd;margin:10px 0}"
+        body := this._MarkdownToHTML(text)
+        ; IE-compatible: prevent context menu and link navigation
+        bodyAttrs := "oncontextmenu='return false'"
+            . " onclick='var el=event.srcElement;"
+            . "while(el&&el.tagName!=" . Chr(34) . "A" . Chr(34) . ")el=el.parentElement;"
+            . "if(el){event.returnValue=false;return false;}'"
+        return "<!DOCTYPE html><html><head>"
+            . "<meta http-equiv='X-UA-Compatible' content='IE=edge'>"
+            . "<meta charset='utf-8'>"
+            . "<style>" . css . "</style>"
+            . "</head><body " . bodyAttrs . ">" . body . "</body></html>"
+    }
+
+    static _MarkdownToHTML(text) {
+        tick3 := Chr(96) . Chr(96) . Chr(96)
+        result := ""
+        inCode := false
+        inList := ""       ; "" | "ul" | "ol"
+        inSubList := false
+        loop parse, text, "`n", "`r" {
+            line := A_LoopField
+            if (SubStr(line, 1, 3) == tick3) {
+                if (!inCode) {
+                    if (inList != "") {
+                        if (inSubList) {
+                            result .= "</ul>"
+                            inSubList := false
+                        }
+                        result .= "</" . inList . ">"
+                        inList := ""
+                    }
+                    result .= "<pre><code>"
+                    inCode := true
+                } else {
+                    result .= "</code></pre>"
+                    inCode := false
+                }
+                continue
+            }
+            if (inCode) {
+                result .= this._HTMLEscape(line) . "`n"
+                continue
+            }
+            if (RegExMatch(line, "^#{2}\s+(.+)", &m)) {
+                if (inList != "") {
+                    if (inSubList) {
+                        result .= "</ul>"
+                        inSubList := false
+                    }
+                    result .= "</" . inList . ">"
+                    inList := ""
+                }
+                result .= "<h2>" . this._HTMLInline(m[1]) . "</h2>"
+                continue
+            }
+            if (RegExMatch(line, "^#\s+(.+)", &m)) {
+                if (inList != "") {
+                    if (inSubList) {
+                        result .= "</ul>"
+                        inSubList := false
+                    }
+                    result .= "</" . inList . ">"
+                    inList := ""
+                }
+                result .= "<h1>" . this._HTMLInline(m[1]) . "</h1>"
+                continue
+            }
+            if (RegExMatch(line, "^(---+|===+)\s*$")) {
+                if (inList != "") {
+                    if (inSubList) {
+                        result .= "</ul>"
+                        inSubList := false
+                    }
+                    result .= "</" . inList . ">"
+                    inList := ""
+                }
+                result .= "<hr>"
+                continue
+            }
+            if (RegExMatch(line, "^(?:  +|\t)[-*]\s+(.+)", &m)) {
+                if (inList == "") {
+                    result .= "<ul>"
+                    inList := "ul"
+                }
+                if (!inSubList) {
+                    result .= "<ul>"
+                    inSubList := true
+                }
+                result .= "<li>" . this._HTMLInline(m[1]) . "</li>"
+                continue
+            }
+            if (RegExMatch(line, "^[-*]\s+(.+)", &m)) {
+                if (inSubList) {
+                    result .= "</ul>"
+                    inSubList := false
+                }
+                if (inList == "ol") {
+                    result .= "</ol>"
+                    inList := ""
+                }
+                if (inList == "") {
+                    result .= "<ul>"
+                    inList := "ul"
+                }
+                result .= "<li>" . this._HTMLInline(m[1]) . "</li>"
+                continue
+            }
+            if (RegExMatch(line, "^\d+\.\s+(.+)", &m)) {
+                if (inSubList) {
+                    result .= "</ul>"
+                    inSubList := false
+                }
+                if (inList == "ul") {
+                    result .= "</ul>"
+                    inList := ""
+                }
+                if (inList == "") {
+                    result .= "<ol>"
+                    inList := "ol"
+                }
+                result .= "<li>" . this._HTMLInline(m[1]) . "</li>"
+                continue
+            }
+            if (Trim(line) == "") {
+                if (inList != "") {
+                    if (inSubList) {
+                        result .= "</ul>"
+                        inSubList := false
+                    }
+                    result .= "</" . inList . ">"
+                    inList := ""
+                }
+                continue
+            }
+            if (inList != "") {
+                if (inSubList) {
+                    result .= "</ul>"
+                    inSubList := false
+                }
+                result .= "</" . inList . ">"
+                inList := ""
+            }
+            result .= "<p>" . this._HTMLInline(line) . "</p>"
+        }
+        if (inSubList)
+            result .= "</ul>"
+        if (inList != "")
+            result .= "</" . inList . ">"
+        if (inCode)
+            result .= "</code></pre>"
+        return result
+    }
+
+    static _HTMLInline(text) {
+        tick := Chr(96)
+        result := ""
+        i := 1
+        len := StrLen(text)
+        while (i <= len) {
+            if (SubStr(text, i, 2) == "**") {
+                j := InStr(text, "**", , i + 2)
+                if (j > 0) {
+                    result .= "<strong>" . this._HTMLEscape(SubStr(text, i + 2, j - i - 2)) . "</strong>"
+                    i := j + 2
+                    continue
+                }
+            } else if (SubStr(text, i, 1) == tick) {
+                j := InStr(text, tick, , i + 1)
+                if (j > 0) {
+                    result .= "<code>" . this._HTMLEscape(SubStr(text, i + 1, j - i - 1)) . "</code>"
+                    i := j + 1
+                    continue
+                }
+            }
+            result .= this._HTMLEscape(SubStr(text, i, 1))
+            i++
+        }
+        return result
+    }
+
+    static _HTMLEscape(str) {
+        str := StrReplace(str, "&", "&amp;")
+        str := StrReplace(str, "<", "&lt;")
+        str := StrReplace(str, ">", "&gt;")
+        return str
     }
 
     static _CleanText(text) {
         text := RegExReplace(text, "[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]", "")  ; 制御文字除去（改行・タブは保持）
+        text := RegExReplace(text, "m)^[•·▪◦]\h*", "- ")                     ; 行頭バレット記号 → Markdownリスト
+        text := RegExReplace(text, "m)^(?![-#\s])(.{1,60})(?=\r?\n- )", "## $1")        ; バレット直前の短い単独行 → 見出し
         text := RegExReplace(text, " {2,}", " ")                              ; 連続空白を1つに
         text := RegExReplace(text, "(\r?\n){3,}", "`n`n")                    ; 連続改行を2つまでに
         return Trim(text)
@@ -475,6 +887,10 @@ class SnapAI {
         autoCopyCheck := sg.Add("CheckBox", "x+5", "結果を自動的にクリップボードにコピー")
         autoCopyCheck.Value := (IniRead(this.IniPath, "Settings", "AutoCopy", "0") == "1") ? 1 : 0
 
+        sg.Add("Text", "xm+10 y+4 w100", "")
+        closeFocusCheck := sg.Add("CheckBox", "x+5", "ウィンドウ外クリックで自動的に閉じる")
+        closeFocusCheck.Value := (IniRead(this.IniPath, "Settings", "CloseOnFocusLost", "0") == "1") ? 1 : 0
+
         ; === プロンプトタブ ===
         tabs.UseTab(2)
         lv := sg.Add("ListView", "xm+10 y+10 w460 h250 -Multi", ["名前", "プロンプト"])
@@ -507,14 +923,14 @@ class SnapAI {
         btnDel.OnEvent("Click",   (*) => (lv.GetNext() ? lv.Delete(lv.GetNext()) : ""))
         btnUp.OnEvent("Click",    (*) => this._MoveListItem(lv, -1))
         btnDown.OnEvent("Click",  (*) => this._MoveListItem(lv, 1))
-        btnOk.OnEvent("Click",    (*) => this._SaveSettings(sg, lv, apiEdit, endpointEdit, modelEdit, tempEdit, tokensEdit, autoCopyCheck))
+        btnOk.OnEvent("Click",    (*) => this._SaveSettings(sg, lv, apiEdit, endpointEdit, modelEdit, tempEdit, tokensEdit, autoCopyCheck, closeFocusCheck))
         btnCancel.OnEvent("Click", (*) => sg.Destroy())
         sg.OnEvent("Close", (*) => sg.Destroy())
 
         sg.Show("AutoSize")
     }
 
-    static _SaveSettings(sg, lv, apiEdit, endpointEdit, modelEdit, tempEdit, tokensEdit, autoCopyCheck) {
+    static _SaveSettings(sg, lv, apiEdit, endpointEdit, modelEdit, tempEdit, tokensEdit, autoCopyCheck, closeFocusCheck) {
         apiKey   := Trim(apiEdit.Value)
         endpoint := Trim(endpointEdit.Value)
         if (!InStr(endpoint, "localhost") && !InStr(endpoint, "127.0.0.1")
@@ -528,8 +944,9 @@ class SnapAI {
         ; コントロール値を事前にキャプチャ
         model    := Trim(modelEdit.Text)
         temp     := Trim(tempEdit.Value)
-        tokens   := Trim(tokensEdit.Value)
-        autoCopy := autoCopyCheck.Value ? "1" : "0"
+        tokens         := Trim(tokensEdit.Value)
+        autoCopy       := autoCopyCheck.Value   ? "1" : "0"
+        closeFocusLost := closeFocusCheck.Value ? "1" : "0"
         prompts  := []
         loop lv.GetCount()
             prompts.Push([lv.GetText(A_Index, 1), lv.GetText(A_Index, 2)])
@@ -544,7 +961,8 @@ class SnapAI {
         IniWrite(model,    this.IniPath, "Settings", "Model")
         IniWrite(temp,     this.IniPath, "Settings", "Temperature")
         IniWrite(tokens,   this.IniPath, "Settings", "MaxTokens")
-        IniWrite(autoCopy, this.IniPath, "Settings", "AutoCopy")
+        IniWrite(autoCopy,       this.IniPath, "Settings", "AutoCopy")
+        IniWrite(closeFocusLost, this.IniPath, "Settings", "CloseOnFocusLost")
         try IniDelete(this.IniPath, "Prompts")
         for p in prompts
             IniWrite(p[2], this.IniPath, "Prompts", p[1])
@@ -552,7 +970,8 @@ class SnapAI {
         sg.Destroy()
         this.ApiKey      := apiKey
         this.ApiEndpoint := endpoint
-        this.AutoCopy    := autoCopy == "1"
+        this.AutoCopy         := autoCopy == "1"
+        this.CloseOnFocusLost := closeFocusLost == "1"
 
         ToolTip("保存しました", , , 4)
         SetTimer(() => ToolTip(, , , 4), -2000)


### PR DESCRIPTION
## Summary
- Rewrote result display to use HTML for richer formatting and improved copy UX
- Made SnapAI.ahk standalone (`#SingleInstance Force`, `SetWorkingDir`, entry point added) — no longer included from Main.ahk
- Fixed ImeControl crash when no active window exists (`WinGetID("A")` now returns false safely)

## Checklist
- [x] Launch SnapAI.ahk directly and confirm `MOD_KEY + T` opens the window
- [x] Verify AI results render correctly as HTML
- [x] Confirm ImeControl does not crash when SnapAI runs alongside Main.ahk
- [x] Verify IME toggle works normally after closing SnapAI window