### PR TITLE
Fix/navi filter and quickswitch

### DIFF
--- a/ui/QuickSwitch.ahk
+++ b/ui/QuickSwitch.ahk
@@ -278,6 +278,9 @@ class QuickSwitch {
                     isMinimized := WinGetMinMax("ahk_id " . hwnd) == -1
                     if isActive && !isMinimized {
                         ; アクティブかつ最小化されていない → 最小化して直前ウィンドウへ復元
+                        ; prevHwnd が自分自身なら復元先がないのでクリア
+                        if (this._prevHwnd == hwnd)
+                            this._prevHwnd := 0
                         WinMinimize("ahk_id " . hwnd)
                         SetTimer(() => this._MinimizeFallback(hwnd, windowPat), this._DELAY_MINIMIZE_CHECK)
                     } else {
@@ -285,9 +288,11 @@ class QuickSwitch {
                         activeId := WinActive("A")
                         if (activeId && activeId != hwnd)
                             this._prevHwnd := activeId
-                        if isMinimized
-                            WinRestore("ahk_id " . hwnd)
-                        WinActivate("ahk_id " . hwnd)
+                        try {
+                            if isMinimized
+                                WinRestore("ahk_id " . hwnd)
+                            WinActivate("ahk_id " . hwnd)
+                        }
                     }
                     return
                 }
@@ -308,7 +313,8 @@ class QuickSwitch {
     static _MinimizeFallback(hwnd, pat) {
         if !WinExist("ahk_id " . hwnd)
             return
-        if (WinGetMinMax("ahk_id " . hwnd) != -1) {
+        minMax := WinGetMinMax("ahk_id " . hwnd)
+        if (minMax != -1) {
             ; まだ最小化されていない → Win+↓ で強制最小化
             WinActivate("ahk_id " . hwnd)
             SendInput("#{Down}")

--- a/ui/navi/Navi.Filter.ahk
+++ b/ui/navi/Navi.Filter.ahk
@@ -336,7 +336,10 @@ class NaviFilter {
             , "UInt*", 0
             , "Ptr",  this._DirOvBuf
             , "Ptr",  0, "Int")
-        ; デバウンス（連続変更をまとめる）
+        ; 変更検知と同時にインデックスを即時無効化（フィルター入力が古いインデックスを使わないよう）
+        this._IndexedRoot := ""
+        this._FolderIndex := []
+        ; デバウンス: フィルター自動再適用のタイミング制御のみ
         if (this._WatchInvCb != "")
             SetTimer(this._WatchInvCb, 0)
         cb := () => this._InvalidateIndex()

--- a/ui/navi/Navi.Tab.ahk
+++ b/ui/navi/Navi.Tab.ahk
@@ -330,6 +330,7 @@ class NaviTab {
         }
         this.UpdateTabBar()
         nv._UpdateStatusBar()
+        nv.GuiObj["TreeFilter"].Focus()
     }
 
     /**

--- a/ui/navi/Navi.ahk
+++ b/ui/navi/Navi.ahk
@@ -377,9 +377,11 @@ class Navi {
         NaviTab.SaveTabsToIni()
         ; パンくず監視タイマーを停止
         NaviBreadcrumb.StopWatcher()
-        ; フィルタータイマーとディレクトリ監視を停止（GUI破棄後に発火するのを防ぐ）
+        ; フィルタータイマー・ディレクトリ監視・インデックスをリセット
+        ; _IndexedRoot を残すと次回起動時に _EnsureIndex が「有効」と誤判定し
+        ; _StartDirWatch が呼ばれないまま古いインデックスを使い続ける
         NaviFilter.CancelDebounce()
-        NaviFilter._StopDirWatch()
+        NaviFilter.ResetForNewRoot()
         ; マーク状態をリセット
         NaviMark.Reset()
         ; プロファイルドロップダウンを閉じる


### PR DESCRIPTION
## Summary
- Fixed stale folder index persisting across Navi sessions — now clears `_IndexedRoot` on close so `_EnsureIndex` always rebuilds and starts `_StartDirWatch` on next open
- Fixed newly created folders not appearing in folder filter when Navi is open — immediately invalidates index in `_PollDirWatch` on directory change instead of waiting for the debounce
- Fixed filter input not receiving focus after switching tabs
- Fixed `prevHwnd` pointing to the same window being minimized, causing no restore target on toggle
- Wrapped `WinRestore`/`WinActivate` in `try` to prevent unhandled errors

## Checklist
- [x] Newly created folders appear in folder filter without switching tabs
- [x] Folder filter index is rebuilt correctly after reopening Navi with a saved filter
- [x] Filter input is focused after tab switch
- [x] QuickSwitch toggle minimizes and restores correctly when `prevHwnd` equals current window