### PR TITLE
## Summary Enable semicolon (;) as a trigger by implementing encoding/decoding for INI storage.  ## Checklist - [x] Semicolon is correctly saved, loaded, and displayed in UI.refactor: introduce tools/ folder for standalone scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 !modules/**/*.ahk
 !ui/**/*.ahk
 !tests/**/*.ahk
+!tools/**/*.ahk
 
 # 5. 上記の許可を上書きしてでも「.ini」は絶対に無視
 *.ini

--- a/README.md
+++ b/README.md
@@ -298,13 +298,12 @@ a::  QuickSwitch.Show()      ; 無変換 + a でデフォルトジャンプ（�
 
 ---
 
-## オプション機能
+## オプションツール (tools/)
 
-### Excel セル操作 (ExcelFontStyle.ahk)
+`tools/` 内の各 `.ahk` を直接起動するだけで有効化（Main.ahk 非依存）。詳細は各ファイル冒頭のコメント参照。
 
-Excel 専用のセル書式・行列操作をホットキーで実行するオプションモジュールです。フォントカラー変更・取り消し線・背景色トグル・行列挿入削除・セル結合解除に対応しています。
-
-> **使用方法**: `modules\ExcelFontStyle.ahk` を直接起動（AutoHotkey で実行）するだけでホットキーが有効になります。`Main.ahk` とは独立して動作します。
+- **ExcelHotkeys.ahk** — Excel セル書式・行列操作のホットキー集
+- **VSCodeGrepClick.ahk** — VSCode で 無変換+クリック → Find in Files 即起動
 
 ---
 
@@ -315,13 +314,15 @@ Excel 専用のセル書式・行列操作をホットキーで実行するオ�
 ├── Main.ahk            # エントリーポイント
 ├── .gitignore          # ホワイトリスト方式の Git 設定
 ├── README.md
-├── modules/            # ロジック・ユーティリティクラス
+├── modules/            # ロジック・ユーティリティクラス（Main.ahk から #Include）
 │   ├── ModifierKeyHandler.ahk  # 修飾キー制御（空打ち検出・キー無効化）
 │   ├── ImeControl.ahk
 │   ├── VimNavigation.ahk
 │   ├── DateTimeInsert.ahk
-│   ├── PlaceholderEngine.ahk   # プレースホルダ置換エンジン（共通）
-│   └── ExcelFontStyle.ahk      # ※オプション（単独起動）
+│   └── PlaceholderEngine.ahk   # プレースホルダ置換エンジン（共通）
+├── tools/              # 単独起動スクリプト（直接実行で動作、Main.ahk 非依存）
+│   ├── ExcelHotkeys.ahk        # Excel セル書式・行列操作
+│   └── VSCodeGrepClick.ahk     # VSCode 無変換+クリックで Find in Files
 ├── lib/                # 共有ライブラリ
 │   └── TempCopy.ahk            # 一時コピーユーティリティ
 ├── temp/               # 一時コピーファイル置き場（TempCopy.ahk が使用）

--- a/tools/ExcelHotkeys.ahk
+++ b/tools/ExcelHotkeys.ahk
@@ -1,5 +1,5 @@
 ; ==============================================================================
-; Module:       ExcelFontStyle.ahk
+; Module:       ExcelHotkeys.ahk
 ; Description:  Excel操作に関連する機能
 ;               - 選択中の文字列を赤色に変更
 ;               - 選択中の文字列を黒色(自動)に変更
@@ -17,7 +17,7 @@
 #SingleInstance Force
 SetWorkingDir A_ScriptDir
 
-class ExcelFontStyle {
+class ExcelHotkeys {
     /**
      * 選択中の文字列を赤にする
      */
@@ -117,13 +117,13 @@ class ExcelFontStyle {
 
 ; 単独起動時のみホットキーを登録
 #HotIf WinActive("ahk_class XLMAIN") && GetKeyState("vk1D", "P")
-e:: ExcelFontStyle.SetFontColorRed()
-q:: ExcelFontStyle.SetFontColorBlack()
-x:: ExcelFontStyle.SetFontColorStrikethrough()
-g:: ExcelFontStyle.ToggleFillColor(0x808080)
-i:: ExcelFontStyle.InsertRow()
-+i:: ExcelFontStyle.InsertColumn()
-d:: ExcelFontStyle.DeleteRow()
-+d:: ExcelFontStyle.DeleteColumn()
-n:: ExcelFontStyle.ToggleMerge()
+e:: ExcelHotkeys.SetFontColorRed()
+q:: ExcelHotkeys.SetFontColorBlack()
+x:: ExcelHotkeys.SetFontColorStrikethrough()
+g:: ExcelHotkeys.ToggleFillColor(0x808080)
+i:: ExcelHotkeys.InsertRow()
++i:: ExcelHotkeys.InsertColumn()
+d:: ExcelHotkeys.DeleteRow()
++d:: ExcelHotkeys.DeleteColumn()
+n:: ExcelHotkeys.ToggleMerge()
 #HotIf

--- a/tools/VSCodeGrepClick.ahk
+++ b/tools/VSCodeGrepClick.ahk
@@ -1,0 +1,47 @@
+; ==============================================================================
+; Module:       VSCodeGrepClick.ahk
+; Description:  VSCode で 無変換+クリック → クリック位置の単語で Find in Files を起動
+;               VSCode の設定 editor.find.seedSearchStringFromSelection = "always"
+;               と組み合わせて、クリック → Ctrl+Shift+F だけで grep を自動入力させる
+; Version:      1.0.0
+; License:      MIT
+;
+; 単独起動専用スクリプト（直接実行）
+; ==============================================================================
+
+#Requires AutoHotkey v2.0
+#SingleInstance Force
+SetWorkingDir A_ScriptDir
+
+; VSCode 上で 無変換(vk1D) を押しながら左クリック → Find in Files
+; combo構文（vk1D & LButton）を使うことで ModifierKeyHandler と共存
+#HotIf WinActive("ahk_exe Code.exe")
+~vk1D & LButton::
+{
+    ; 既存の選択範囲を確認（Ctrl+C で取得、クリップボードは即復元）
+    savedClip := ClipboardAll()
+    A_Clipboard := ""
+    Send "^c"
+    ClipWait 0.2, 0
+    selText := A_Clipboard
+    A_Clipboard := savedClip
+
+    ; VSCode は選択なしで Ctrl+C すると現在行が末尾改行付きでコピーされるため、
+    ; 末尾が改行でない場合のみ「単一行の選択」と判定する
+    hasSelection := selText != ""
+        && SubStr(selText, -1) != "`n"
+        && SubStr(selText, -1) != "`r"
+
+    if (hasSelection) {
+        ; 選択あり → クリックせず（解除されないように）、選択をそのまま使う
+        Send "^+f"   ; Find in Files（VSCode 設定で選択が自動入力される）
+    } else {
+        ; 選択なし → クリック位置の単語を選択して検索
+        Click
+        Sleep 50
+        Send "^d"    ; VSCode: カーソル位置の単語を選択
+        Sleep 50
+        Send "^+f"
+    }
+}
+#HotIf


### PR DESCRIPTION
## Summary
Introduce `tools/` folder to separate standalone executable scripts from library modules, and add a new VSCode grep shortcut.

## Checklist
- [x] `tools/` is whitelisted in .gitignore so its `.ahk` files are tracked
- [x] ExcelFontStyle renamed to ExcelHotkeys (covers font, row/column, merge — not just font)
- [x] VSCodeGrepClick triggers Find in Files on Muhenkan+Click in VSCode
- [x] README folder structure reflects new layout