### PR TITLE
fix(navi): keep first filter match visible on multiple hits

### DIFF
--- a/ui/navi/Navi.Filter.ahk
+++ b/ui/navi/Navi.Filter.ahk
@@ -494,7 +494,7 @@ class NaviFilter {
                 tv.Add("… 上位 " . filterResultCap . " 件を表示（キーワードを追加して絞り込んでください）", rootID)
             addedPaths := Map()
             addedPaths[StrLower(rootBase)] := rootID
-            firstMatch := true
+            firstMatchID := 0
             for idx, fullPath in results {
                 if (this._FilterCancelled)
                     return
@@ -518,11 +518,12 @@ class NaviFilter {
                         parentID := existingID
                     } else {
                         opts := isMatch ? "Bold" : ""
-                        if (isMatch && firstMatch) {
-                            opts      .= " Select"
-                            firstMatch := false
-                        }
+                        ; 先頭マッチに Select を付け、ノードIDを記録（末尾で可視化に使用）
+                        if (isMatch && firstMatchID == 0)
+                            opts .= " Select"
                         nodeID := tv.Add(part, parentID, opts . " Icon1")
+                        if (isMatch && firstMatchID == 0)
+                            firstMatchID := nodeID
                         if (isMatch) {
                             this._FilterMatchIdSet[nodeID] := true
                             tv.Add("...loading...", nodeID)  ; ノード作成直後に追加して展開ボタンを即表示
@@ -533,6 +534,19 @@ class NaviFilter {
                 }
                 ; 50件ごとに GUI イベントを処理してUIの応答性を保つ
                 if (Mod(idx, 50) = 0)
+                    Sleep(0)
+            }
+            ; マッチしたフォルダの実子フォルダを自動表示（フィルタにマッチしない兄弟も含めて表示）
+            matchLoopCount := 0
+            for matchID, _ in this._FilterMatchIdSet {
+                if (this._FilterCancelled)
+                    return
+                ; "...loading..." プレースホルダーを削除してから実子をロード
+                placeholder := tv.GetChild(matchID)
+                if (placeholder != 0 && tv.GetText(placeholder) == "...loading...")
+                    tv.Delete(placeholder)
+                nv._LoadFilterSub(tv, matchID)
+                if (Mod(++matchLoopCount, 20) == 0)
                     Sleep(0)
             }
             ; 子を持つノードを展開（"...loading..." プレースホルダーのみのノードは展開しない）
@@ -577,6 +591,10 @@ class NaviFilter {
             }
             ; フィルタ結果の上にマーク色を復元
             NaviMark._RebuildMarkedIdSet(tv)
+            ; 実子ロード・展開・ファイル表示で下方向にスクロールし先頭マッチが
+            ; 上端で見切れるのを防ぐため、最後に先頭マッチを完全可視化する
+            if (firstMatchID != 0)
+                tv.Modify(firstMatchID, "Vis")
         } catch Any {
             ; GUI 破棄など想定内の例外は無視して finally でクリーンアップ
         } finally {

--- a/ui/navi/Navi.Tab.ahk
+++ b/ui/navi/Navi.Tab.ahk
@@ -502,8 +502,11 @@ class NaviTab {
             NaviFilter.EnsureFilterDraw(tv)
             DllCall("user32\InvalidateRect", "ptr", tv.Hwnd, "ptr", 0, "int", 1)
         }
-        if (state.path != "" && rootPath != "")
+        if (state.path != "" && rootPath != "") {
             nv._FocusPath(tv, state.path)
+            ; フィルタ非同期完了後にも復元できるよう目標パスを保存
+            nv._RestoreTargetPath := state.path
+        }
     }
 
     /**

--- a/ui/navi/Navi.ahk
+++ b/ui/navi/Navi.ahk
@@ -63,6 +63,8 @@ class Navi {
     static QuickPathHwnd := 0
     static _TreeFilterFocused := false
     static FilesShown := Map()
+    static _EnsureSelectionVisibleRetries := 0  ; Show 後の選択スクロールリトライ回数
+    static _RestoreTargetPath := ""             ; Show 後にリトライ復元する目標パス
     ; 詳細リスト関連状態は NaviDetailList クラスで管理（Navi.DetailList.ahk）
     ; パンくず関連定数・状態は NaviBreadcrumb クラスで管理（Navi.Breadcrumb.ahk）
     static _AllFolderNames := []  ; 全ルート名リスト（フィルタ前）
@@ -310,7 +312,51 @@ class Navi {
         centerY := waT + (waB - waT - winH) // 2
 
         this.GuiObj.Show("x" . centerX . " y" . centerY . " w" . winW . " h" . winH)
+        ; GUI 表示後に選択項目を再度可視化（フィルタの非同期処理を考慮して複数回リトライ）
+        this._EnsureSelectionVisibleRetries := 0
+        this._EnsureSelectionVisible()
         this.GuiObj["TreeFilter"].Focus()
+    }
+
+    /**
+     * 選択項目を可視範囲にスクロール（フィルタ非同期完了を待つため最大 10 回リトライ）
+     * 復元目標パスがあれば、選択が一致するまで _FocusPath をリトライする
+     */
+    static _EnsureSelectionVisible() {
+        if !(this.GuiObj && WinExist(this.GuiObj))
+            return
+        tv := this.GuiObj["FolderTree"]
+        targetPath := this._RestoreTargetPath
+        if (targetPath != "") {
+            ; 現在の選択が目標パスと一致しているかチェック
+            selId := tv.GetSelection()
+            matched := false
+            if (selId) {
+                try {
+                    if (StrLower(this._GetTVFullPath(tv, selId)) == StrLower(targetPath))
+                        matched := true
+                }
+            }
+            if (matched) {
+                tv.Modify(selId, "Vis")
+                this._RestoreTargetPath := ""
+                return
+            }
+            ; まだ一致してない → _FocusPath で再試行
+            if (DirExist(targetPath) || FileExist(targetPath))
+                this._FocusPath(tv, targetPath)
+        } else {
+            ; 復元目標なし → 現在の選択を可視化するだけ
+            selId := tv.GetSelection()
+            if (selId) {
+                tv.Modify(selId, "Vis")
+                return
+            }
+        }
+        if (++this._EnsureSelectionVisibleRetries < 10)
+            SetTimer(this._EnsureSelectionVisible.Bind(this), -100)
+        else
+            this._RestoreTargetPath := ""  ; リトライ上限 → 諦める
     }
 
     static _FocusPath(tv, targetPath) {
@@ -1367,8 +1413,14 @@ class Navi {
             ; ルートボタン → ツリーフィルター欄へ
             this.GuiObj["TreeFilter"].Focus()
         } else if (this.GuiObj.HasOwnProp("_treeFilterHwnd") && currFocus = this.GuiObj._treeFilterHwnd) {
-            ; ツリーフィルター欄 → ツリーへ（Down は通さず先頭選択状態を維持）
-            this.GuiObj["FolderTree"].Focus()
+            ; ツリーフィルター欄 → ツリーへ。選択がない場合は前回保存パスを復元
+            tv := this.GuiObj["FolderTree"]
+            if (tv.GetSelection() == 0 && NaviTab._CurrentTab <= NaviTab._Tabs.Length) {
+                tab := NaviTab._Tabs[NaviTab._CurrentTab]
+                if (tab != "" && tab.path != "" && (DirExist(tab.path) || FileExist(tab.path)))
+                    this._FocusPath(tv, tab.path)
+            }
+            tv.Focus()
         } else {
             ; それ以外（ツリー上など）→ Down をツリーへ送る
             PostMessage(0x0100, 0x28, 0, this._tvHwnd)  ; WM_KEYDOWN VK_DOWN


### PR DESCRIPTION
## Summary
Fix the folder filter so the first match stays visible when several folders match. Previously, after the tree finished loading children and expanding nodes, the view scrolled down and clipped the top hit off-screen.

## Checklist
- [x] First matched folder is fully visible (not clipped at the top) on multiple hits
- [x] Selection is re-revealed after the async folder index finishes
- [x] Previously focused folder is restored when returning to the tree