### PR TITLE
feat(excel): add click-to-format popup panel

### DIFF
--- a/tools/ExcelHotkeys.ahk
+++ b/tools/ExcelHotkeys.ahk
@@ -1,13 +1,16 @@
 ; ==============================================================================
 ; Module:       ExcelHotkeys.ahk
 ; Description:  Excel操作に関連する機能
-;               - 選択中の文字列を赤色に変更
-;               - 選択中の文字列を黒色(自動)に変更
-;               - 選択範囲の取り消し線(Strikethrough)を切り替え
-;               - セルの背景色トグル
-;               - 行・列の挿入/削除
-;               - セルの結合/解除トグル
-; Version:      1.2.0
+;               - 文字色（赤/黒）・取り消し線
+;               - 背景色（黄/灰）と塗りつぶしなし
+;               - 罫線（格子/外枠/なし）・揃え（左/中央/右）
+;               - セルの結合/解除・書式のクリア・折り返して全体表示
+;               - 行・列の挿入/削除（ホットキーのみ）
+;               - クリック用ポップアップパネル（無変換+Shift 2回でマウス位置に表示）
+;                 ホットキーを忘れても・誤爆が怖くても、アイコンボタンをクリックして
+;                 操作できる（ホバーで名前表示）。ボタンを選ぶ・マウスが離れる・
+;                 Excel を離れると自動で閉じる。汎用部品 FloatingPanel.ahk を利用。
+; Version:      1.4.0
 ; License:      MIT
 ;
 ; 単独起動（直接実行）またはMain.ahkからの #Include 両方に対応
@@ -16,6 +19,8 @@
 #Requires AutoHotkey v2.0
 #SingleInstance Force
 SetWorkingDir A_ScriptDir
+
+#Include "FloatingPanel.ahk"
 
 class ExcelHotkeys {
     /**
@@ -55,6 +60,10 @@ class ExcelHotkeys {
     /**
      * セルの背景色を指定色と塗りつぶしなしでトグル
      * color: BGR形式の色コード (例: 0x808080)
+     * ※特定色の塗りはリボンに固定キーが無く、色を正確に出すため COM を使用。
+     *   COM 変更は Ctrl+Z で戻せない（undo 履歴も消える）。ただしセルの値は
+     *   壊さないため、当初懸念の「文字が消える」系の危険とは別物。誤ったら
+     *   「塗りつぶしなし」（キー操作＝戻せる）で消せる。
      */
     static ToggleFillColor(color) {
         if !WinActive("ahk_class XLMAIN")
@@ -70,6 +79,45 @@ class ExcelHotkeys {
             MsgBox("Excel操作失敗: " . e.Message)
         }
     }
+
+    /**
+     * 塗りつぶしを解除（「塗りつぶしなし」）。
+     * 「塗りつぶしなし」はリボンに固定キー(Alt+H+H→N)があるためキー操作で行い、
+     * Ctrl+Z で元に戻せる（特定色の黄/灰は固定キーが無いので COM のまま）。
+     */
+    static ClearFillColor() {
+        if !WinActive("ahk_class XLMAIN")
+            return
+        Send("{Alt}hh")   ; 塗りつぶし色メニューを開く
+        Sleep(150)
+        Send("n")         ; 塗りつぶしなし
+    }
+
+    ; --- リボン経由の書式操作（キー送信なので Ctrl+Z で元に戻せる） ---
+    ; 1発で送れるもの（キーチップ列を続けて送る）
+    static _Ribbon(keys) {
+        if !WinActive("ahk_class XLMAIN")
+            return
+        Send(keys)
+    }
+    ; サブメニューを開いてから項目を選ぶもの（メニューが開くのを待ってから項目キー）
+    static _RibbonSub(openKeys, itemKey) {
+        if !WinActive("ahk_class XLMAIN")
+            return
+        Send(openKeys)
+        Sleep(150)
+        Send(itemKey)
+    }
+
+    static AlignLeft()      => this._Ribbon("{Alt}hal")   ; 左揃え
+    static AlignCenter()    => this._Ribbon("{Alt}hac")   ; 中央揃え
+    static AlignRight()     => this._Ribbon("{Alt}har")   ; 右揃え
+    static ToggleWrapText() => this._Ribbon("{Alt}hw")    ; 折り返して全体表示
+
+    static BordersAll()     => this._RibbonSub("{Alt}hb", "a")  ; すべての罫線(格子)
+    static BordersOutline() => this._RibbonSub("{Alt}hb", "s")  ; 外枠
+    static BordersNone()    => this._RibbonSub("{Alt}hb", "n")  ; 罫線なし
+    static ClearFormats()   => this._RibbonSub("{Alt}he", "f")  ; 書式のクリア(値は残す)
 
     static InsertRow() {
         if !WinActive("ahk_class XLMAIN")
@@ -113,7 +161,121 @@ class ExcelHotkeys {
         else
             Send("{Alt}hmm")   ; セルの結合（中央揃えなし）
     }
+
+    ; ==========================================================================
+    ; クリック用フローティングパネル（FloatingPanel.ahk を利用）
+    ; ホットキーを覚えなくても・誤爆が怖くても、ラベル付きボタンをクリックで操作。
+    ; パネルは NOACTIVATE なのでクリックしても Excel からフォーカスを奪わず、
+    ; 各操作の WinActive("ahk_class XLMAIN") ガードを満たしたまま送信できる。
+    ; ==========================================================================
+    static _panel    := ""
+    static _IniPath  => A_ScriptDir . "\ExcelHotkeys.ini"
+    static TRAY_ITEM := "Excel パネルを表示/非表示"
+    static _shiftTapTick    := 0    ; 直前に Shift を押した時刻（二度押し判定用）
+    static SHIFT_TAP_WINDOW := 400  ; この ms 以内に 2 回目が来たら二度押しと判定
+
+    /**
+     * パネルのボタン定義（▼ ここを編集。各行が独立なのでカンマ管理は不要）
+     *   - 追加     : b.Push(...) の行を足す（既存行をコピペでOK）
+     *   - 非表示   : 行を削除 or 先頭に ";" を付けてコメントアウト
+     *   - 並べ替え : 行を上下に移動するだけ
+     *   - 見出し   : b.Push({ group: "見出し" }) でグループ区切り（列カウントもリセット）
+     * フィールド: label=アイコン文字(必須) / tip=ホバー説明(推奨) / action=処理(必須) /
+     *            color=文字色(省略可) / bg=背景色(省略可) / font=フォント(省略可) / h=高さ(省略可)
+     * アイコンのみだと分かりにくいため tip でマウスホバー時に名前を表示する。
+     * 記号: A=文字色 / ■=塗り色スウォッチ / ▢=塗りなし / ▦◻⬚=罫線 / ◫=結合
+     * 色の例: 白FFFFFF 灰CCCCCC 緑89D185 青4FC1FF 黄F2D024 赤F48771
+     */
+    static _PanelButtons() {
+        b := []
+        b.Push({ group: "文字" })
+        b.Push({ label: "A",   tip: "文字を赤",        color: "F48771", action: () => ExcelHotkeys.SetFontColorRed() })
+        b.Push({ label: "A",   tip: "文字を黒(自動)",  color: "E0E0E0", action: () => ExcelHotkeys.SetFontColorBlack() })
+        b.Push({ label: "S̶",   tip: "取り消し線",      color: "CCCCCC", action: () => ExcelHotkeys.SetFontColorStrikethrough() })
+        b.Push({ group: "塗り" })
+        b.Push({ label: "■",   tip: "背景色 ： 黄",    color: "F2D024", action: () => ExcelHotkeys.ToggleFillColor(0xFFFF) })
+        b.Push({ label: "■",   tip: "背景色 ： 灰",    color: "9A9A9A", action: () => ExcelHotkeys.ToggleFillColor(0x808080) })
+        b.Push({ label: "▢",   tip: "背景色 ： なし",  color: "CCCCCC", action: () => ExcelHotkeys.ClearFillColor() })
+        b.Push({ group: "罫線" })
+        b.Push({ label: "▦",   tip: "格子（全罫線）", color: "CCCCCC", action: () => ExcelHotkeys.BordersAll() })
+        b.Push({ label: "◻",   tip: "外枠",          color: "CCCCCC", action: () => ExcelHotkeys.BordersOutline() })
+        b.Push({ label: "⬚",   tip: "罫線なし",      color: "888888", action: () => ExcelHotkeys.BordersNone() })
+        b.Push({ group: "揃え" })
+        ; 整列アイコンは Segoe MDL2 Assets のグリフを使用（AlignLeft/Center/Right）
+        b.Push({ label: Chr(0xE8E4), font: "Segoe MDL2 Assets", tip: "左揃え",   color: "CCCCCC", action: () => ExcelHotkeys.AlignLeft() })
+        b.Push({ label: Chr(0xE8E3), font: "Segoe MDL2 Assets", tip: "中央揃え", color: "CCCCCC", action: () => ExcelHotkeys.AlignCenter() })
+        b.Push({ label: Chr(0xE8E2), font: "Segoe MDL2 Assets", tip: "右揃え",   color: "CCCCCC", action: () => ExcelHotkeys.AlignRight() })
+        b.Push({ group: "セル" })
+        b.Push({ label: "◫",         tip: "セルの結合 / 解除",   color: "4FC1FF", action: () => ExcelHotkeys.ToggleMerge() })
+        b.Push({ label: "🧹",        tip: "書式のクリア（値は残す）", color: "CCCCCC", action: () => ExcelHotkeys.ClearFormats() })
+        b.Push({ label: "↵",         tip: "折り返して全体表示",     color: "CCCCCC", action: () => ExcelHotkeys.ToggleWrapText() })
+        return b
+    }
+    ; ※ 行/列の挿入・削除は誤操作防止のためパネルには置かず、ホットキーに残している
+    ;    挿入: 無変換+i / 無変換+Shift+i    削除: 無変換+d / 無変換+Shift+d
+
+    ; パネルインスタンスを遅延生成して返す
+    static _GetPanel() {
+        if (this._panel == "")
+            this._panel := FloatingPanel({
+                name:    "excel",
+                title:   "Excel",
+                iniPath: this._IniPath,
+                width:    134,   ; 3列ぶんの幅（大きく/小さく）
+                fontSize: 15,    ; アイコンサイズ（上げるとパネルも拡大）
+                columns:  3,     ; 各グループ(3個)がちょうど1行に収まる
+                btnHeight: 26,   ; ボタン高（余白を詰める）
+                opacity:  255,   ; 透過度 0-255（例: 220 で少し透ける）
+                popup:    true,  ; カーソル位置に一時表示（選ぶ/離れると消える）
+                activeWhen: () => WinActive("ahk_class XLMAIN"),  ; Excel を離れたら自動で閉じる
+                onVisible: (v) => ExcelHotkeys._SyncTray(v),  ; 全経路でトレイのチェックを同期
+                buttons: this._PanelButtons()
+            })
+        return this._panel
+    }
+
+    /**
+     * フローティングパネルをマウスカーソル位置にトグル表示
+     */
+    static TogglePanel() {
+        this._GetPanel().ToggleAtCursor()
+    }
+
+    /**
+     * 無変換を押しながら Shift を素早く2回 → パネルをトグル。
+     * （~Shift で拾うため Shift 本来の動作はそのまま。Shift 単体は Excel で
+     *   何も起きないので passthrough でも安全。修飾キーは自動リピートしないので
+     *   「2回押し」は必ず2回の独立した押下になる）
+     */
+    static OnShiftDoubleTap() {
+        now := A_TickCount
+        if (now - this._shiftTapTick <= this.SHIFT_TAP_WINDOW) {
+            this._shiftTapTick := 0
+            this.TogglePanel()
+        } else {
+            this._shiftTapTick := now
+        }
+    }
+
+    /**
+     * トレイメニューにパネル切替項目を追加する（ホットキーを忘れても操作可能）
+     */
+    static SetupTray() {
+        tray := A_TrayMenu
+        tray.Add()  ; 区切り線
+        tray.Add(this.TRAY_ITEM, (*) => ExcelHotkeys.TogglePanel())
+        tray.Default := this.TRAY_ITEM
+        tray.Add("パネル設定…（透過/サイズ）", (*) => ExcelHotkeys._GetPanel().ShowSettings())
+    }
+
+    ; トレイメニューのチェック状態をパネル表示状態に同期（未登録でも安全）
+    static _SyncTray(visible) {
+        try visible ? A_TrayMenu.Check(this.TRAY_ITEM) : A_TrayMenu.Uncheck(this.TRAY_ITEM)
+    }
 }
+
+; トレイメニューからもパネルを切り替えられるようにする（ホットキーを忘れても操作可能）
+ExcelHotkeys.SetupTray()
 
 ; 単独起動時のみホットキーを登録
 #HotIf WinActive("ahk_class XLMAIN") && GetKeyState("vk1D", "P")
@@ -126,4 +288,9 @@ i:: ExcelHotkeys.InsertRow()
 d:: ExcelHotkeys.DeleteRow()
 +d:: ExcelHotkeys.DeleteColumn()
 n:: ExcelHotkeys.ToggleMerge()
+; 無変換を押しながら Shift を素早く2回でパネルをマウス位置にポップアップ
+; （~ で Shift 本来の動作は保持。L/R どちらの Shift でも可。Ctrl はクイック分析等と
+;   干渉するため Shift を採用）
+~LShift:: ExcelHotkeys.OnShiftDoubleTap()
+~RShift:: ExcelHotkeys.OnShiftDoubleTap()
 #HotIf

--- a/tools/FloatingPanel.ahk
+++ b/tools/FloatingPanel.ahk
@@ -24,6 +24,13 @@
 ;     })
 ;     panel.Toggle()   ; / .Show() / .Hide() / .IsVisible() / .SetOpacity(220) / .ShowSettings()
 ;
+;   常駐ではなくカーソル位置に一時表示したい場合は popup:true を渡し、
+;   panel.ToggleAtCursor()（または .ShowAtCursor()）で呼ぶ。
+;   ボタン実行後・マウスが離れた時・activeWhen()==false で自動的に閉じる。
+;     panel := FloatingPanel({ ..., popup:true,
+;              activeWhen:() => WinActive("ahk_class XLMAIN") })
+;     panel.ToggleAtCursor()
+;
 ; パネルを右クリックするとコンテキストメニュー（設定… / 非表示 / 追加項目）が開く。
 ; 設定ダイアログ（透過度/文字サイズ/幅）の変更は即 INI に保存され次回も復元される。
 ; cfg.menuItems: [{text:"...", action:() => ...}] でメニュー項目を追加できる。
@@ -46,8 +53,9 @@ class FloatingPanel {
                             , border:   true }
 
     /**
-     * cfg: { name, title, buttons[, iniPath, width, theme] }
-     *   buttons: [{label, action[, color, bg, h]}]
+     * cfg: { name, title, buttons[, iniPath, width, fontSize, btnHeight, opacity,
+     *        columns, gap, popup, activeWhen, dismissMargin, onVisible, menuItems, theme] }
+     *   buttons 要素: {label, action[, tip, color, bg, font, h]} または {group:"見出し"}
      */
     __New(cfg) {
         this.title     := cfg.HasOwnProp("title")     ? cfg.title     : "Panel"
@@ -60,14 +68,23 @@ class FloatingPanel {
         this.buttons   := cfg.buttons
         this.menuItems := cfg.HasOwnProp("menuItems") ? cfg.menuItems : []  ; 右クリックメニューの追加項目 [{text, action}]
         this.onVisible := cfg.HasOwnProp("onVisible") ? cfg.onVisible : ""  ; 表示状態変化のコールバック (visible:bool)
+        ; ポップアップ運用: ShowAtCursor でカーソル位置に一時表示し、ボタン実行後・
+        ; マウスが離れた時・activeWhen が false になった時に自動で閉じる
+        this.popup         := cfg.HasOwnProp("popup")         ? cfg.popup         : false
+        this.activeWhen    := cfg.HasOwnProp("activeWhen")    ? cfg.activeWhen    : ""   ; () => bool。false で自動クローズ
+        this.dismissMargin := cfg.HasOwnProp("dismissMargin") ? cfg.dismissMargin : 70   ; パネル矩形からこの px 以上マウスが離れたら閉じる
+        this.columns       := cfg.HasOwnProp("columns")       ? cfg.columns       : 1    ; ボタンを横に並べる列数（>1 でグリッド）
+        this.gap           := cfg.HasOwnProp("gap")           ? cfg.gap           : 4    ; 列間の隙間(px)
         this.theme     := this._MergeTheme(cfg.HasOwnProp("theme") ? cfg.theme : {})
         this.gui         := ""
         this.hdrHwnd     := 0
         this.btns        := Map()
         this.hoverHwnd   := 0
         this.settingsGui := ""
-        this._loaded     := false                              ; INI 設定の初回読込済みフラグ
-        this._rebuildTimer := ObjBindMethod(this, "_Rebuild")  ; サイズ変更のデバウンス用
+        this._loaded     := false                                ; INI 設定の初回読込済みフラグ
+        this._rebuildTimer  := ObjBindMethod(this, "_Rebuild")   ; サイズ変更のデバウンス用
+        this._dismissTimer  := ObjBindMethod(this, "_DismissTick") ; ポップアップの自動クローズ監視
+        this._shownTick     := 0                                 ; ShowAtCursor した時刻（表示直後の猶予判定用）
     }
 
     _MergeTheme(o) {
@@ -94,17 +111,107 @@ class FloatingPanel {
         }
         x := this._LoadPos("X", A_ScreenWidth - 200)
         y := this._LoadPos("Y", A_ScreenHeight // 3)
+        ; 復元位置が全モニターの作業領域外なら既定位置にリセット（モニター構成変更で見えなくなるのを防ぐ）
+        if !this._IsPosOnScreen(x, y) {
+            x := A_ScreenWidth - 200
+            y := A_ScreenHeight // 3
+        }
         this.gui.Show("NoActivate x" . x . " y" . y)
         this._ApplyOpacity()
         this._FireVisible(true)
     }
 
+    /**
+     * 指定座標が現在接続中のいずれかのモニター作業領域内にあるか判定
+     */
+    _IsPosOnScreen(x, y) {
+        Loop MonitorGetCount() {
+            try {
+                MonitorGetWorkArea(A_Index, &mL, &mT, &mR, &mB)
+                if (x >= mL && x < mR && y >= mT && y < mB)
+                    return true
+            }
+        }
+        return false
+    }
+
     Hide() {
         if (this.gui != "") {
-            this._SavePos()
+            SetTimer(this._dismissTimer, 0)   ; ポップアップ監視を止める（未起動でも安全）
+            ToolTip()                         ; ホバー説明が残らないよう消す
+            this.hoverHwnd := 0
+            if (!this.popup)
+                this._SavePos()               ; ポップアップは常にカーソル位置なので保存しない
             this.gui.Hide()
             this._FireVisible(false)
         }
+    }
+
+    ; --- ポップアップ表示（カーソル位置に一時表示して選ばせる） ---
+
+    ToggleAtCursor() => this.IsVisible() ? this.Hide() : this.ShowAtCursor()
+
+    /**
+     * マウスカーソルの位置にパネルを一時表示する（NOACTIVATE）。
+     * ボタン実行後・マウスが離れた時・activeWhen が false になった時に自動で閉じる。
+     */
+    ShowAtCursor() {
+        if (this.gui == "") {
+            this._LoadSettings()
+            this._Build()
+        }
+        CoordMode("Mouse", "Screen")
+        MouseGetPos(&mx, &my)
+        ; まず暫定位置（カーソルがヘッダー付近に来るよう少し左上）で表示してサイズを確定
+        this.gui.Show("NoActivate x" . (mx - 24) . " y" . (my - 12))
+        this.gui.GetPos(&gx, &gy, &pw, &ph)
+        ; 作業領域からはみ出す分だけクランプ（カーソルのあるモニター内）
+        this._MonitorWorkAreaAt(mx, my, &L, &T, &R, &B)
+        nx := Min(Max(gx, L), R - pw)
+        ny := Min(Max(gy, T), B - ph)
+        if (nx != gx || ny != gy)
+            this.gui.Move(nx, ny)
+        this._ApplyOpacity()
+        this._shownTick := A_TickCount
+        SetTimer(this._dismissTimer, 120)
+        this._FireVisible(true)
+    }
+
+    ; ポップアップの自動クローズ監視
+    _DismissTick() {
+        if (this.gui == "" || !this.IsVisible()) {
+            SetTimer(this._dismissTimer, 0)
+            return
+        }
+        ; 対象アプリ（例: Excel）から離れたら閉じる
+        if (this.activeWhen && !this.activeWhen.Call()) {
+            this.Hide()
+            return
+        }
+        ; 表示直後は閉じない（呼び出し位置とボタンの間を移動する猶予）
+        if (A_TickCount - this._shownTick < 500)
+            return
+        ; マウスがパネル矩形＋マージンの外に出たら閉じる
+        CoordMode("Mouse", "Screen")
+        MouseGetPos(&mx, &my)
+        this.gui.GetPos(&gx, &gy, &gw, &gh)
+        m := this.dismissMargin
+        if (mx < gx - m || mx > gx + gw + m || my < gy - m || my > gy + gh + m)
+            this.Hide()
+    }
+
+    ; 指定座標を含むモニターの作業領域を返す（無ければプライマリ）
+    _MonitorWorkAreaAt(x, y, &L, &T, &R, &B) {
+        Loop MonitorGetCount() {
+            try {
+                MonitorGetWorkArea(A_Index, &mL, &mT, &mR, &mB)
+                if (x >= mL && x < mR && y >= mT && y < mB) {
+                    L := mL, T := mT, R := mR, B := mB
+                    return
+                }
+            }
+        }
+        MonitorGetWorkArea(MonitorGetPrimary(), &L, &T, &R, &B)
     }
 
     _FireVisible(visible) {
@@ -239,16 +346,42 @@ class FloatingPanel {
         g.SetFont("s" . (this.fontSize - 2), "Segoe UI")
         hdr := g.AddText(Format("w{1} h{2} +0x100 +0x200 Center c{3} Background{4}", this.width, headerH, t.header, t.bg), "≡  " . this.title)
         ; ボタン（Win32 標準を避け Text コントロールで自作 → 暗色フラット & 色自由）
+        ; buttons の要素が {group:"見出し"} なら区切り（列カウントをリセット）。
+        ; columns>1 で各グループ内を左→右に埋めてグリッド配置する。
         g.SetFont("s" . this.fontSize, "Segoe UI")
         this.btns := Map()
+        cols := this.columns < 1 ? 1 : this.columns
+        gap  := this.gap
+        colW := (cols > 1) ? ((this.width - (cols - 1) * gap) // cols) : this.width
+        hdrFs := (this.fontSize - 4 < 8) ? 8 : this.fontSize - 4
+        col := 0
         for b in this.buttons {
+            if b.HasOwnProp("group") {
+                col := 0
+                if (b.group != "") {
+                    g.SetFont("s" . hdrFs, "Segoe UI")
+                    g.AddText(Format("xm w{1} +0x200 c{2} Background{3}", this.width, t.header, t.bg), b.group)
+                    g.SetFont("s" . this.fontSize, "Segoe UI")
+                } else {
+                    g.AddText(Format("xm w{1} h2 Background{2}", this.width, t.header))  ; 見出しなし=区切り線
+                }
+                continue
+            }
             h   := b.HasOwnProp("h")     ? b.h     : this.btnHeight
             bg  := b.HasOwnProp("bg")    ? b.bg    : t.btn
             txt := b.HasOwnProp("color") ? b.color : t.txt
-            ctrl := g.AddText(Format("xm w{1} h{2} +0x100 +0x200 Center Background{3} c{4}", this.width, h, bg, txt), b.label)
+            pos := (col = 0) ? Format("xm w{1} h{2}", colW, h)
+                             : Format("x+{1} yp w{2} h{3}", gap, colW, h)
+            if b.HasOwnProp("font")   ; アイコンフォント等をボタン単位で指定（例: Segoe MDL2 Assets）
+                g.SetFont("s" . this.fontSize, b.font)
+            ctrl := g.AddText(pos . " +0x100 +0x200 Center Background" . bg . " c" . txt, b.label)
+            if b.HasOwnProp("font")
+                g.SetFont("s" . this.fontSize, "Segoe UI")
             ctrl.OnEvent("Click", this._MakeClick(b.action))
-            this.btns[ctrl.Hwnd] := { ctrl: ctrl, bg: bg, txt: txt, hbg: t.btnHover, htxt: t.txtHover }
+            tip := b.HasOwnProp("tip") ? b.tip : ""   ; アイコンのみのボタン向けホバー説明
+            this.btns[ctrl.Hwnd] := { ctrl: ctrl, bg: bg, txt: txt, hbg: t.btnHover, htxt: t.txtHover, tip: tip }
             FloatingPanel._owner[ctrl.Hwnd] := this
+            col := Mod(col + 1, cols)
         }
         this.gui     := g
         this.hdrHwnd := hdr.Hwnd
@@ -258,7 +391,14 @@ class FloatingPanel {
     }
 
     ; ボタン押下コールバックを別スコープで生成（ループ内クロージャの取り違え防止）
-    _MakeClick(action) => (*) => action()
+    _MakeClick(action) => (*) => this._Invoke(action)
+
+    ; ボタン/メニュー実行。ポップアップ運用では実行後にパネルを閉じる
+    _Invoke(action) {
+        action()
+        if (this.popup)
+            this.Hide()
+    }
 
     ; --- 位置の保存／復元 ---
 
@@ -296,6 +436,7 @@ class FloatingPanel {
     _HandleMouseMove(hwnd) {
         if (!this.btns.Has(hwnd)) {
             this._ResetHover()
+            ToolTip()
             return
         }
         if (this.hoverHwnd = hwnd)
@@ -305,6 +446,7 @@ class FloatingPanel {
         this._SetBtnColors(info, info.hbg, info.htxt)
         this.hoverHwnd := hwnd
         this._TrackLeave(hwnd)
+        (info.tip != "") ? ToolTip(info.tip) : ToolTip()   ; アイコンの説明を表示
     }
 
     _HandleMouseLeave(hwnd) {
@@ -314,6 +456,7 @@ class FloatingPanel {
             if (this.hoverHwnd = hwnd)
                 this.hoverHwnd := 0
         }
+        ToolTip()   ; パネルから離れたら説明を消す
     }
 
     ; WM_MOUSELEAVE を発生させるため TrackMouseEvent を登録


### PR DESCRIPTION
# Summary
Add a click-to-format popup panel for Excel. Pressing Muhenkan+Shift twice (or the tray item) pops a small icon panel up at the mouse cursor; click an icon to apply a format and it auto-closes when you pick one, move the mouse away, or leave Excel — so you don't have to remember the shortcuts, and stray hotkey misfires that could wipe a cell are avoided. Buttons are icon-only, grouped by font / fill / borders / alignment / cell, each with a hover tooltip. Formats that have stable ribbon keys (borders, alignment, wrap, clear-formatting, no-fill) are sent as keystrokes so Ctrl+Z works; only the exact fill colors (yellow/gray) use COM. Row/column insert & delete stay on hotkeys, off the panel. The reusable FloatingPanel gains a popup-at-cursor mode, a multi-column grid with group headers, per-button tooltips / icon fonts, and an off-screen position guard.

## Checklist
- [x] Panel opens at the cursor via Muhenkan+Shift twice and via the tray, and auto-closes on pick / mouse-away / leaving Excel
- [x] Icons render and hover tooltips show each action's name
- [x] Existing Excel hotkeys (font color, strikethrough, merge, row/column insert/delete) still work
- [x] Each panel button performs its action in real Excel (ribbon-key sequences confirmed)
- [x] Ctrl+Z undoes borders / alignment / wrap / clear-formatting / no-fill